### PR TITLE
Pin GitHub Actions to specific commit SHAs and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/backend-integration-test.yaml
+++ b/.github/workflows/backend-integration-test.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Build Components
         id: build
-        uses: OpenVidu/actions/build-openvidu-components-angular@main
+        uses: OpenVidu/actions/build-openvidu-components-angular@75a45bb035204455a22016d78b28d7370a39432f # v1.0.1
     outputs:
       artifact_name: ${{ steps.build.outputs.artifact_name }}
 
@@ -51,16 +51,16 @@ jobs:
         run: curl -sSL https://get.livekit.io/cli | bash
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22.13'
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 10.18.3
 
       - name: Setup OpenVidu Local Deployment
-        uses: OpenVidu/actions/start-openvidu-local-deployment@main
+        uses: OpenVidu/actions/start-openvidu-local-deployment@75a45bb035204455a22016d78b28d7370a39432f # v1.0.1
         with:
           ref-openvidu-local-deployment: development
           pre_startup_commands: |
@@ -74,7 +74,7 @@ jobs:
             chmod +x pre_startup_commands.sh && ./pre_startup_commands.sh
 
       - name: Setup OpenVidu Meet
-        uses: OpenVidu/actions/start-openvidu-meet@main
+        uses: OpenVidu/actions/start-openvidu-meet@75a45bb035204455a22016d78b28d7370a39432f # v1.0.1
         with:
           build_components_angular: 'true'
           components_artifact_name: ${{ needs.build-components.outputs.artifact_name }}
@@ -86,14 +86,14 @@ jobs:
 
       - name: Upload OpenVidu Meet logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ matrix.test-name }}-openvidu-meet-logs
           path: meet_backend.log
           retention-days: 2
 
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@db71d41eb79864e25ab0337e395c352e84523afe # v4.3.1
         if: always()
         with:
           report_paths: '**/reports/junit.xml'
@@ -102,7 +102,7 @@ jobs:
 
       - name: Clean up
         if: always()
-        uses: OpenVidu/actions/cleanup@main
+        uses: OpenVidu/actions/cleanup@75a45bb035204455a22016d78b28d7370a39432f # v1.0.1
 
   start-aws-runner-s3:
     name: Prepare AWS runner (S3)
@@ -114,7 +114,7 @@ jobs:
     steps:
       - name: Start AWS EC2 Runner
         id: start-ec2-runner
-        uses: OpenVidu/actions/start-aws-runner@main
+        uses: OpenVidu/actions/start-aws-runner@75a45bb035204455a22016d78b28d7370a39432f # v1.0.1
         with:
           aws-instance-type: ${{ inputs.aws-instance-type || 'c5.2xlarge' }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -137,7 +137,7 @@ jobs:
     steps:
       - name: Start AWS EC2 Runner
         id: start-ec2-runner
-        uses: OpenVidu/actions/start-aws-runner@main
+        uses: OpenVidu/actions/start-aws-runner@75a45bb035204455a22016d78b28d7370a39432f # v1.0.1
         with:
           aws-instance-type: ${{ inputs.aws-instance-type || 'c5.2xlarge' }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -160,7 +160,7 @@ jobs:
     steps:
       - name: Start AWS EC2 Runner
         id: start-ec2-runner
-        uses: OpenVidu/actions/start-aws-runner@main
+        uses: OpenVidu/actions/start-aws-runner@75a45bb035204455a22016d78b28d7370a39432f # v1.0.1
         with:
           aws-instance-type: ${{ inputs.aws-instance-type || 'c5.2xlarge' }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -189,11 +189,11 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22.13'
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b # v2.4.1
         with:
           version: 10
       - name: Install LK CLI
@@ -232,7 +232,7 @@ jobs:
             gsutil -m rm -r gs://openvidu-appdata/openvidu-meet/ || echo "No files found to delete or bucket doesn't exist"
           fi
       - name: Setup OpenVidu Local Deployment
-        uses: OpenVidu/actions/start-openvidu-local-deployment@main
+        uses: OpenVidu/actions/start-openvidu-local-deployment@75a45bb035204455a22016d78b28d7370a39432f # v1.0.1
         with:
           ref-openvidu-local-deployment: development
           pre_startup_commands: |
@@ -266,7 +266,7 @@ jobs:
             chmod +x pre_startup_commands.sh && ./pre_startup_commands.sh
 
       - name: Setup OpenVidu Meet
-        uses: OpenVidu/actions/start-openvidu-meet@main
+        uses: OpenVidu/actions/start-openvidu-meet@75a45bb035204455a22016d78b28d7370a39432f # v1.0.1
         with:
           build_components_angular: 'true'
           components_artifact_name: ${{ needs.build-components.outputs.artifact_name }}
@@ -294,7 +294,7 @@ jobs:
           MEET_S3_BUCKET: ${{ matrix.storage-provider == 'gcs' && 'openvidu-appdata' || 'openvidu-appdata' }}
 
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@db71d41eb79864e25ab0337e395c352e84523afe # v4.3.1
         if: always()
         with:
           report_paths: '**/reports/junit.xml'
@@ -303,7 +303,7 @@ jobs:
 
       - name: Upload OpenVidu Meet logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: recordings-test-${{ matrix.storage-provider }}-openvidu-meet-logs
           path: meet_backend.log
@@ -317,7 +317,7 @@ jobs:
 
       - name: Clean up
         if: always()
-        uses: OpenVidu/actions/cleanup@main
+        uses: OpenVidu/actions/cleanup@75a45bb035204455a22016d78b28d7370a39432f # v1.0.1
 
   stop-runner:
     name: Stop EC2 runner (${{ matrix.storage-provider }})
@@ -335,7 +335,7 @@ jobs:
     steps:
       - name: Stop AWS EC2 Runner
         if: ${{ (matrix.storage-provider == 's3' && needs.start-aws-runner-s3.result != 'skipped') || (matrix.storage-provider == 'abs' && needs.start-aws-runner-abs.result != 'skipped') || (matrix.storage-provider == 'gcs' && needs.start-aws-runner-gcs.result != 'skipped') }}
-        uses: OpenVidu/actions/stop-aws-runner@main
+        uses: OpenVidu/actions/stop-aws-runner@75a45bb035204455a22016d78b28d7370a39432f # v1.0.1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -354,6 +354,6 @@ jobs:
     if: ${{ always() }}
     steps:
       - name: Remove Artifact
-        uses: geekyeggo/delete-artifact@v5
+        uses: geekyeggo/delete-artifact@f275313e70c08f6120db482d7a6b98377786765b # v5.1.0
         with:
           name: ${{ needs.build-components.outputs.artifact_name }}

--- a/.github/workflows/backend-unit-test.yaml
+++ b/.github/workflows/backend-unit-test.yaml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ${{ vars.LABEL_WORKER_SELFHOSTED }}
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22.13'
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 10.18.3
       - name: Checkout OpenVidu Meet
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install dependencies
         run: ./meet.sh install
@@ -32,7 +32,7 @@ jobs:
           JEST_JUNIT_OUTPUT_DIR: './backend/reports/'
 
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@db71d41eb79864e25ab0337e395c352e84523afe # v4.3.1
         if: always()
         with:
           report_paths: '**/reports/junit.xml'
@@ -41,4 +41,4 @@ jobs:
 
       - name: Clean up
         if: always()
-        uses: OpenVidu/actions/cleanup@main
+        uses: OpenVidu/actions/cleanup@75a45bb035204455a22016d78b28d7370a39432f # v1.0.1

--- a/.github/workflows/wc-e2e-test.yaml
+++ b/.github/workflows/wc-e2e-test.yaml
@@ -10,17 +10,17 @@ jobs:
     runs-on: ${{ vars.LABEL_WORKER_SELFHOSTED }}
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22.13'
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 10.18.3
       - name: Install LK CLI
         run: curl -sSL https://get.livekit.io/cli | bash
       - name: Setup OpenVidu Local Deployment
-        uses: OpenVidu/actions/start-openvidu-local-deployment@main
+        uses: OpenVidu/actions/start-openvidu-local-deployment@75a45bb035204455a22016d78b28d7370a39432f # v1.0.1
         with:
           ref-openvidu-local-deployment: development
           pre_startup_commands: |
@@ -34,13 +34,13 @@ jobs:
             chmod +x pre_startup_commands.sh && ./pre_startup_commands.sh
 
       - name: Build and Start OpenVidu Meet
-        uses: OpenVidu/actions/start-openvidu-meet@main
+        uses: OpenVidu/actions/start-openvidu-meet@75a45bb035204455a22016d78b28d7370a39432f # v1.0.1
         env:
           MEET_INITIAL_WEBHOOK_ENABLED: true
           MEET_INITIAL_WEBHOOK_URL: 'http://localhost:5080/webhook'
 
       - name: Start OpenVidu Meet Testapp
-        uses: OpenVidu/actions/start-openvidu-meet-testapp@main
+        uses: OpenVidu/actions/start-openvidu-meet-testapp@75a45bb035204455a22016d78b28d7370a39432f # v1.0.1
         with:
           skip_install: 'true'
           skip_checkout: 'true'
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: room-test-results
           path: meet-ce/frontend/webcomponent/test-results/
@@ -63,7 +63,7 @@ jobs:
 
       - name: Upload TestApp logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: room-test-testapp-logs
           path: testapp.log
@@ -71,7 +71,7 @@ jobs:
 
       - name: Upload OpenVidu Meet logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: room-test-openvidu-meet-logs
           path: meet_backend.log
@@ -79,4 +79,4 @@ jobs:
 
       - name: Clean up
         if: always()
-        uses: OpenVidu/actions/cleanup@main
+        uses: OpenVidu/actions/cleanup@75a45bb035204455a22016d78b28d7370a39432f # v1.0.1

--- a/.github/workflows/wc-unit-test.yaml
+++ b/.github/workflows/wc-unit-test.yaml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ${{ vars.LABEL_WORKER_SELFHOSTED }}
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '22.13'
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           version: 10.18.3
       - name: Checkout OpenVidu Meet
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install dependencies
         run: ./meet.sh install
@@ -34,4 +34,4 @@ jobs:
 
       - name: Clean up
         if: always()
-        uses: OpenVidu/actions/cleanup@main
+        uses: OpenVidu/actions/cleanup@75a45bb035204455a22016d78b28d7370a39432f # v1.0.1


### PR DESCRIPTION
## Summary

- Add Dependabot configuration for weekly GitHub Actions dependency updates
- Pin all action references to immutable commit SHAs instead of mutable tags (e.g. `@v4`, `@main`)
- Affected actions: `actions/checkout`, `actions/setup-node`, `actions/upload-artifact`, `pnpm/action-setup`, `mikepenz/action-junit-report`, `geekyeggo/delete-artifact`, `OpenVidu/actions/*`

## Why

Pinning to commit SHAs prevents supply chain attacks where a tag could be moved to point to malicious code. This is a [GitHub security best practice](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

Dependabot will keep the pinned SHAs up to date automatically.