### PR TITLE
add skip-lobby and skip-prejoin query params for configurable meeting…

### DIFF
--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/pages/meeting/meeting.component.html
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/pages/meeting/meeting.component.html
@@ -16,7 +16,7 @@
 } @else if (!isMeetingLeft()) {
 	<ov-videoconference
 		[token]="roomMemberToken()!"
-		[prejoin]="true"
+		[prejoin]="!skipPrejoin()"
 		[prejoinDisplayParticipantName]="false"
 		[videoEnabled]="features().videoEnabled"
 		[audioEnabled]="features().audioEnabled"

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/pages/meeting/meeting.component.ts
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/pages/meeting/meeting.component.ts
@@ -95,6 +95,10 @@ export class MeetingComponent implements OnInit {
 	protected roomSecret = computed(() => this.meetingContextService.roomSecret());
 	protected hasRecordings = computed(() => this.meetingContextService.hasRecordings());
 
+	// === CONFIGURABLE SKIP SIGNALS (from query params) ===
+	protected skipPrejoin = computed(() => this.meetingContextService.skipPrejoin());
+	protected shouldSkipLobby = computed(() => this.meetingContextService.skipLobby());
+
 	constructor() {
 		this.features = this.featureConfService.features;
 
@@ -134,6 +138,10 @@ export class MeetingComponent implements OnInit {
 		try {
 			await this.lobbyService.initialize();
 			this.isLobbyReady = true;
+
+			if (this.shouldSkipLobby()) {
+				await this.lobbyService.submitAccess();
+			}
 		} catch (error) {
 			console.error('Error initializing lobby state:', error);
 			this.notificationService.showDialog({

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/routes/meeting.routes.ts
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/routes/meeting.routes.ts
@@ -17,7 +17,12 @@ export const meetingDomainRoutes: DomainRouteConfig[] = [
 				runGuardsSerially(
 					extractRoomQueryParamsGuard,
 					validateRoomAccessGuard,
-					removeQueryParamsGuard(['secret', WebComponentProperty.E2EE_KEY])
+					removeQueryParamsGuard([
+						'secret',
+						WebComponentProperty.E2EE_KEY,
+						WebComponentProperty.SKIP_LOBBY,
+						WebComponentProperty.SKIP_PREJOIN
+					])
 				)
 			]
 		}

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/services/meeting-context.service.ts
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/services/meeting-context.service.ts
@@ -32,6 +32,8 @@ export class MeetingContextService {
 	private readonly _participantsVersion = signal<number>(0);
 	private readonly _localParticipant = signal<CustomParticipantModel | undefined>(undefined);
 	private readonly _remoteParticipants = signal<CustomParticipantModel[]>([]);
+	private readonly _skipLobby = signal<boolean>(false);
+	private readonly _skipPrejoin = signal<boolean>(false);
 
 	/**
 	 * Readonly signal for the current room
@@ -88,6 +90,16 @@ export class MeetingContextService {
 	 * Readonly signal for the remote participants
 	 */
 	readonly remoteParticipants = this._remoteParticipants.asReadonly();
+
+	/**
+	 * Readonly signal for whether to skip the lobby screen
+	 */
+	readonly skipLobby = this._skipLobby.asReadonly();
+
+	/**
+	 * Readonly signal for whether to skip the prejoin screen
+	 */
+	readonly skipPrejoin = this._skipPrejoin.asReadonly();
 
 	/**
 	 * Computed signal that combines local and remote participants
@@ -184,6 +196,20 @@ export class MeetingContextService {
 	}
 
 	/**
+	 * Sets whether to skip the lobby screen
+	 */
+	setSkipLobby(skip: boolean): void {
+		this._skipLobby.set(skip);
+	}
+
+	/**
+	 * Sets whether to skip the prejoin screen
+	 */
+	setSkipPrejoin(skip: boolean): void {
+		this._skipPrejoin.set(skip);
+	}
+
+	/**
 	 * Returns whether E2EE is enabled (has a key set)
 	 * @returns true if E2EE is enabled, false otherwise
 	 */
@@ -251,5 +277,7 @@ export class MeetingContextService {
 		this._participantsVersion.set(0);
 		this._localParticipant.set(undefined);
 		this._remoteParticipants.set([]);
+		this._skipLobby.set(false);
+		this._skipPrejoin.set(false);
 	}
 }

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/services/meeting-lobby.service.ts
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/services/meeting-lobby.service.ts
@@ -127,6 +127,7 @@ export class MeetingLobbyService {
 	 */
 	setParticipantName(name: string): void {
 		this._state().participantForm.get('name')?.setValue(name);
+		this._state.update((state) => ({ ...state }));
 	}
 
 	/**
@@ -134,6 +135,7 @@ export class MeetingLobbyService {
 	 */
 	setE2eeKey(key: string): void {
 		this._state().participantForm.get('e2eeKey')?.setValue(key);
+		this._state.update((state) => ({ ...state }));
 	}
 
 	/**

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/shared/adapters/meeting-context.adapter.ts
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/shared/adapters/meeting-context.adapter.ts
@@ -19,6 +19,16 @@ export interface MeetingContextAdapter {
 	 * Sets the E2EE encryption key for the current meeting
 	 */
 	setE2eeKey(key: string): void;
+
+	/**
+	 * Sets whether to skip the lobby screen
+	 */
+	setSkipLobby(skip: boolean): void;
+
+	/**
+	 * Sets whether to skip the prejoin screen
+	 */
+	setSkipPrejoin(skip: boolean): void;
 }
 
 /**

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/shared/guards/extract-query-params.guard.ts
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/shared/guards/extract-query-params.guard.ts
@@ -19,7 +19,9 @@ export const extractRoomQueryParamsGuard: CanActivateFn = (route: ActivatedRoute
 		participantName,
 		leaveRedirectUrl,
 		showOnlyRecordings,
-		e2eeKey: queryE2eeKey
+		e2eeKey: queryE2eeKey,
+		skipLobby,
+		skipPrejoin
 	} = extractParams(route);
 	const secret = querySecret || sessionStorageService.getRoomSecret();
 	const e2eeKey = queryE2eeKey || sessionStorageService.getE2EEKey();
@@ -41,6 +43,14 @@ export const extractRoomQueryParamsGuard: CanActivateFn = (route: ActivatedRoute
 
 	if (participantName) {
 		roomMemberAdapter.setParticipantName(participantName);
+	}
+
+	if (skipLobby === 'true') {
+		meetingContextAdapter.setSkipLobby(true);
+	}
+
+	if (skipPrejoin === 'true') {
+		meetingContextAdapter.setSkipPrejoin(true);
 	}
 
 	if (showOnlyRecordings === 'true') {
@@ -76,7 +86,9 @@ const extractParams = ({ params, queryParams }: ActivatedRouteSnapshot) => ({
 	participantName: queryParams[WebComponentProperty.PARTICIPANT_NAME] as string,
 	leaveRedirectUrl: queryParams[WebComponentProperty.LEAVE_REDIRECT_URL] as string,
 	showOnlyRecordings: (queryParams[WebComponentProperty.SHOW_ONLY_RECORDINGS] as string) || 'false',
-	e2eeKey: queryParams[WebComponentProperty.E2EE_KEY] as string
+	e2eeKey: queryParams[WebComponentProperty.E2EE_KEY] as string,
+	skipLobby: (queryParams[WebComponentProperty.SKIP_LOBBY] as string) || 'false',
+	skipPrejoin: (queryParams[WebComponentProperty.SKIP_PREJOIN] as string) || 'false'
 });
 
 /**

--- a/meet-ce/typings/src/webcomponent/properties.model.ts
+++ b/meet-ce/typings/src/webcomponent/properties.model.ts
@@ -28,5 +28,18 @@ export enum WebComponentProperty {
     /**
      * Whether to show only recordings instead of live meetings.
      */
-    SHOW_ONLY_RECORDINGS = 'show-only-recordings'
+    SHOW_ONLY_RECORDINGS = 'show-only-recordings',
+
+    /**
+     * Whether to skip the lobby screen (participant name input).
+     * Requires `participant-name` to be provided via query params.
+     * Default: false (lobby is shown)
+     */
+    SKIP_LOBBY = 'skip-lobby',
+
+    /**
+     * Whether to skip the prejoin screen (camera/mic preview).
+     * Default: false (prejoin is shown)
+     */
+    SKIP_PREJOIN = 'skip-prejoin'
 }


### PR DESCRIPTION
… entry

## Summary
- Added two new optional query parameters `skip-lobby` and `skip-prejoin` that allow bypassing the lobby screen (participant name input) and the prejoin screen (camera/mic preview) when joining a meeting.
- When `skip-lobby=true` is set (requires `participant-name` to be provided), the participant is automatically submitted into the meeting without showing the lobby form.
- When `skip-prejoin=true` is set, the camera/mic preview screen is skipped and the user enters the video call directly.
- Fixed a signal reactivity issue in `MeetingLobbyService` where `setParticipantName()` and `setE2eeKey()` mutated the form inside the signal without triggering re-evaluation of computed signals.

## Usage

/room/ROOM_ID?secret=XXX&participant-name=John&skip-lobby=true&skip-prejoin=true

Both parameters are optional and default to `false`, making this change fully backwards compatible. They can be used independently or together, and work with both direct URL access and the `<openvidu-meet>` web component attributes.

## Test plan

- [ ] Access a room URL without new params — lobby and prejoin should appear as before
- [ ] Access with `skip-lobby=true&participant-name=Test` — lobby is skipped, prejoin appears
- [ ] Access with `skip-prejoin=true` — lobby appears, prejoin is skipped after joining
- [ ] Access with both `skip-lobby=true&skip-prejoin=true&participant-name=Test` — enters call directly
- [ ] Verify participant name appears correctly in the video call when using skip-lobby
- [ ] Verify query params are cleaned from the URL after extraction