### PR TITLE
feat(meet): add guest captcha, room passcode, and advanced room media policies

### DIFF
--- a/meet-ce/backend/src/config/dependency-injector.config.ts
+++ b/meet-ce/backend/src/config/dependency-injector.config.ts
@@ -15,46 +15,47 @@ import { UserRepository } from '../repositories/user.repository.js';
  * helps avoid dependency cycles and ensures constructors receive the
  * dependencies already registered in the container.
  */
-import { LoggerService } from '../services/logger.service.js';
-import { RedisService } from '../services/redis.service.js';
-import { DistributedEventService } from '../services/distributed-event.service.js';
-import { MutexService } from '../services/mutex.service.js';
-import { TaskSchedulerService } from '../services/task-scheduler.service.js';
 import { BaseUrlService } from '../services/base-url.service.js';
+import { DistributedEventService } from '../services/distributed-event.service.js';
+import { LoggerService } from '../services/logger.service.js';
+import { MutexService } from '../services/mutex.service.js';
+import { RedisService } from '../services/redis.service.js';
 import { RequestSessionService } from '../services/request-session.service.js';
+import { TaskSchedulerService } from '../services/task-scheduler.service.js';
 
-import { TokenService } from '../services/token.service.js';
-import { UserService } from '../services/user.service.js';
 import { ApiKeyService } from '../services/api-key.service.js';
 import { GlobalConfigService } from '../services/global-config.service.js';
+import { TokenService } from '../services/token.service.js';
+import { UserService } from '../services/user.service.js';
 
-import { S3Service } from '../services/storage/providers/s3/s3.service.js';
+import { ABSStorageProvider } from '../services/storage/providers/abs/abs-storage.provider.js';
+import { ABSService } from '../services/storage/providers/abs/abs.service.js';
+import { GCSStorageProvider } from '../services/storage/providers/gcp/gcs-storage.provider.js';
+import { GCSService } from '../services/storage/providers/gcp/gcs.service.js';
 import { S3KeyBuilder } from '../services/storage/providers/s3/s3-storage-key.builder.js';
 import { S3StorageProvider } from '../services/storage/providers/s3/s3-storage.provider.js';
-import { ABSService } from '../services/storage/providers/abs/abs.service.js';
-import { ABSStorageProvider } from '../services/storage/providers/abs/abs-storage.provider.js';
-import { GCSService } from '../services/storage/providers/gcp/gcs.service.js';
-import { GCSStorageProvider } from '../services/storage/providers/gcp/gcs-storage.provider.js';
+import { S3Service } from '../services/storage/providers/s3/s3.service.js';
 
+import { BlobStorageService } from '../services/storage/blob-storage.service.js';
 import { MongoDBService } from '../services/storage/mongodb.service.js';
 import { StorageInitService } from '../services/storage/storage-init.service.js';
-import { StorageKeyBuilder, StorageProvider } from '../services/storage/storage.interface.js';
 import { StorageFactory } from '../services/storage/storage.factory.js';
-import { BlobStorageService } from '../services/storage/blob-storage.service.js';
+import { StorageKeyBuilder, StorageProvider } from '../services/storage/storage.interface.js';
 
-import { MigrationService } from '../services/migration.service.js';
-import { LiveKitService } from '../services/livekit.service.js';
-import { FrontendEventService } from '../services/frontend-event.service.js';
-import { RecordingService } from '../services/recording.service.js';
-import { RoomService } from '../services/room.service.js';
-import { ParticipantNameService } from '../services/participant-name.service.js';
-import { RoomMemberService } from '../services/room-member.service.js';
-import { OpenViduWebhookService } from '../services/openvidu-webhook.service.js';
-import { LivekitWebhookService } from '../services/livekit-webhook.service.js';
-import { RoomScheduledTasksService } from '../services/room-scheduled-tasks.service.js';
-import { RecordingScheduledTasksService } from '../services/recording-scheduled-tasks.service.js';
-import { AnalyticsService } from '../services/analytics.service.js';
 import { AiAssistantService } from '../services/ai-assistant.service.js';
+import { AnalyticsService } from '../services/analytics.service.js';
+import { CaptchaService } from '../services/captcha.service.js';
+import { FrontendEventService } from '../services/frontend-event.service.js';
+import { LivekitWebhookService } from '../services/livekit-webhook.service.js';
+import { LiveKitService } from '../services/livekit.service.js';
+import { MigrationService } from '../services/migration.service.js';
+import { OpenViduWebhookService } from '../services/openvidu-webhook.service.js';
+import { ParticipantNameService } from '../services/participant-name.service.js';
+import { RecordingScheduledTasksService } from '../services/recording-scheduled-tasks.service.js';
+import { RecordingService } from '../services/recording.service.js';
+import { RoomMemberService } from '../services/room-member.service.js';
+import { RoomScheduledTasksService } from '../services/room-scheduled-tasks.service.js';
+import { RoomService } from '../services/room.service.js';
 
 export const container: Container = new Container();
 
@@ -115,6 +116,7 @@ export const registerDependencies = () => {
 	container.bind(RecordingScheduledTasksService).toSelf().inSingletonScope();
 	container.bind(AnalyticsService).toSelf().inSingletonScope();
 	container.bind(AiAssistantService).toSelf().inSingletonScope();
+	container.bind(CaptchaService).toSelf().inSingletonScope();
 };
 
 const configureStorage = (storageMode: string) => {

--- a/meet-ce/backend/src/controllers/global-config.controller.ts
+++ b/meet-ce/backend/src/controllers/global-config.controller.ts
@@ -3,6 +3,7 @@ import { Request, Response } from 'express';
 import { container } from '../config/dependency-injector.config.js';
 import { MEET_ENV } from '../environment.js';
 import { handleError } from '../models/error.model.js';
+import { CaptchaService } from '../services/captcha.service.js';
 import { GlobalConfigService } from '../services/global-config.service.js';
 import { LoggerService } from '../services/logger.service.js';
 import { OpenViduWebhookService } from '../services/openvidu-webhook.service.js';
@@ -120,5 +121,19 @@ export const getCaptionsConfig = async (_req: Request, res: Response) => {
 		return res.status(200).json({ enabled: captionsEnabled });
 	} catch (error) {
 		handleError(res, error, 'getting captions config');
+	}
+};
+
+export const getGuestCaptchaConfig = async (_req: Request, res: Response) => {
+	const logger = container.get(LoggerService);
+	const captchaService = container.get(CaptchaService);
+
+	logger.verbose('Getting guest captcha config');
+
+	try {
+		const guestCaptchaConfig = captchaService.getGuestCaptchaConfig();
+		return res.status(200).json(guestCaptchaConfig);
+	} catch (error) {
+		handleError(res, error, 'getting guest captcha config');
 	}
 };

--- a/meet-ce/backend/src/environment.ts
+++ b/meet-ce/backend/src/environment.ts
@@ -83,11 +83,15 @@ export const MEET_ENV = {
 	// Live Captions configuration
 	CAPTIONS_ENABLED: process.env.MEET_CAPTIONS_ENABLED || 'false',
 
+	// Guest captcha configuration
+	GUEST_CAPTCHA_ENABLED: process.env.MEET_GUEST_CAPTCHA_ENABLED || 'false',
+	GUEST_CAPTCHA_SITE_KEY: process.env.MEET_GUEST_CAPTCHA_SITE_KEY ?? '',
+	GUEST_CAPTCHA_SECRET_KEY: process.env.MEET_GUEST_CAPTCHA_SECRET_KEY ?? '',
+
 	// Deployment configuration
 	MODULES_FILE: process.env.MODULES_FILE || undefined,
 	MODULE_NAME: process.env.MODULE_NAME || 'openviduMeet',
-	ENABLED_MODULES: process.env.ENABLED_MODULES ?? '',
-
+	ENABLED_MODULES: process.env.ENABLED_MODULES ?? ''
 };
 
 export function checkModuleEnabled() {

--- a/meet-ce/backend/src/helpers/room.helper.ts
+++ b/meet-ce/backend/src/helpers/room.helper.ts
@@ -2,6 +2,9 @@ import { MeetRoom, MeetRoomOptions } from '@openvidu-meet/typings';
 import { MEET_ENV } from '../environment.js';
 
 export class MeetRoomHelper {
+	private static readonly ROOM_PASSCODE_CHARSET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+	private static readonly ROOM_PASSCODE_LENGTH = 8;
+
 	private constructor() {
 		// Prevent instantiation of this utility class
 	}
@@ -26,6 +29,26 @@ export class MeetRoomHelper {
 	 */
 	static sanitizeRoomId(val: string): string {
 		return val.replace(/[^a-zA-Z0-9_-]/g, ''); // Allow only letters, numbers, hyphens and underscores
+	}
+
+	/**
+	 * Sanitizes a room passcode by trimming and uppercasing it.
+	 */
+	static sanitizeRoomPasscode(val: string): string {
+		return val.trim().toUpperCase();
+	}
+
+	/**
+	 * Creates a random 8-character alphanumeric room passcode.
+	 */
+	static createRoomPasscode(): string {
+		let passcode = '';
+		for (let i = 0; i < MeetRoomHelper.ROOM_PASSCODE_LENGTH; i++) {
+			const randomIndex = Math.floor(Math.random() * MeetRoomHelper.ROOM_PASSCODE_CHARSET.length);
+			passcode += MeetRoomHelper.ROOM_PASSCODE_CHARSET[randomIndex];
+		}
+
+		return passcode;
 	}
 
 	/**
@@ -62,10 +85,10 @@ export class MeetRoomHelper {
 	static toOpenViduOptions(room: MeetRoom): MeetRoomOptions {
 		return {
 			roomName: room.roomName,
+			maxParticipants: room.maxParticipants,
 			autoDeletionDate: room.autoDeletionDate,
 			autoDeletionPolicy: room.autoDeletionPolicy,
 			config: room.config
-			// maxParticipants: room.maxParticipants
 		};
 	}
 

--- a/meet-ce/backend/src/middlewares/captcha.middleware.ts
+++ b/meet-ce/backend/src/middlewares/captcha.middleware.ts
@@ -1,0 +1,25 @@
+import { MeetRoomMemberTokenOptions } from '@openvidu-meet/typings';
+import { NextFunction, Request, Response } from 'express';
+import { container } from '../config/dependency-injector.config.js';
+import { handleError } from '../models/error.model.js';
+import { CaptchaService } from '../services/captcha.service.js';
+
+export const validateGuestCaptcha = async (req: Request, res: Response, next: NextFunction) => {
+	const captchaService = container.get(CaptchaService);
+
+	if (!captchaService.isGuestCaptchaEnabled()) {
+		return next();
+	}
+
+	const tokenOptions = req.body as MeetRoomMemberTokenOptions;
+	if (!tokenOptions.grantJoinMeetingPermission) {
+		return next();
+	}
+
+	try {
+		await captchaService.validateGuestCaptcha(tokenOptions.captchaToken, req.headers['x-forwarded-for'] || req.ip);
+		return next();
+	} catch (error) {
+		return handleError(res, error, 'validating captcha');
+	}
+};

--- a/meet-ce/backend/src/models/error.model.ts
+++ b/meet-ce/backend/src/models/error.model.ts
@@ -205,8 +205,20 @@ export const errorRoomActiveMeeting = (roomId: string): OpenViduMeetError => {
 	return new OpenViduMeetError('Room Error', `Room '${roomId}' has an active meeting`, 409);
 };
 
+export const errorRoomMaxParticipantsReached = (roomId: string, maxParticipants: number): OpenViduMeetError => {
+	return new OpenViduMeetError(
+		'Room Error',
+		`Room '${roomId}' has reached the maximum number of participants (${maxParticipants})`,
+		409
+	);
+};
+
 export const errorInvalidRoomSecret = (roomId: string, secret: string): OpenViduMeetError => {
 	return new OpenViduMeetError('Room Error', `Secret '${secret}' is not recognized for room '${roomId}'`, 400);
+};
+
+export const errorInvalidRoomPasscode = (roomId: string): OpenViduMeetError => {
+	return new OpenViduMeetError('Room Error', `Invalid passcode for room '${roomId}'`, 403);
 };
 
 export const errorDeletingRoom = (errorCode: MeetRoomDeletionErrorCode, message: string): OpenViduMeetError => {
@@ -243,6 +255,24 @@ export const errorApiKeyNotConfiguredForWebhooks = (): OpenViduMeetError => {
 		'There are no API keys configured yet. Please, create one to use webhooks.',
 		400
 	);
+};
+
+// Captcha errors
+
+export const errorCaptchaNotConfigured = (): OpenViduMeetError => {
+	return new OpenViduMeetError(
+		'Captcha Error',
+		'Captcha is enabled but not configured correctly on server side',
+		500
+	);
+};
+
+export const errorCaptchaTokenRequired = (): OpenViduMeetError => {
+	return new OpenViduMeetError('Captcha Error', 'Captcha token is required to join the meeting', 400);
+};
+
+export const errorCaptchaValidationFailed = (): OpenViduMeetError => {
+	return new OpenViduMeetError('Captcha Error', 'Captcha validation failed', 403);
 };
 
 // Handlers

--- a/meet-ce/backend/src/models/mongoose-schemas/room.schema.ts
+++ b/meet-ce/backend/src/models/mongoose-schemas/room.schema.ts
@@ -4,8 +4,10 @@ import {
 	MeetRoom,
 	MeetRoomDeletionPolicyWithMeeting,
 	MeetRoomDeletionPolicyWithRecordings,
+	MeetRoomMediaMode,
 	MeetRoomStatus,
 	MeetRoomThemeMode,
+	MeetScreenShareAccess,
 	MeetingEndAction
 } from '@openvidu-meet/typings';
 import { Document, Schema, model } from 'mongoose';
@@ -120,6 +122,28 @@ const MeetCaptionsConfigSchema = new Schema(
 	{ _id: false }
 );
 
+const MeetMediaConfigSchema = new Schema(
+	{
+		mode: {
+			type: String,
+			enum: Object.values(MeetRoomMediaMode),
+			required: true
+		}
+	},
+	{ _id: false }
+);
+
+const MeetScreenShareConfigSchema = new Schema(
+	{
+		allowAccessTo: {
+			type: String,
+			enum: Object.values(MeetScreenShareAccess),
+			required: true
+		}
+	},
+	{ _id: false }
+);
+
 /**
  * Sub-schema for room theme configuration.
  */
@@ -199,6 +223,14 @@ const MeetRoomConfigSchema = new Schema(
 		captions: {
 			type: MeetCaptionsConfigSchema,
 			required: true
+		},
+		media: {
+			type: MeetMediaConfigSchema,
+			required: true
+		},
+		screenShare: {
+			type: MeetScreenShareConfigSchema,
+			required: true
 		}
 	},
 	{ _id: false }
@@ -223,9 +255,19 @@ const MeetRoomSchema = new Schema<MeetRoomDocument>(
 			type: String,
 			required: true
 		},
+		passcode: {
+			type: String,
+			required: false,
+			unique: true,
+			sparse: true
+		},
 		creationDate: {
 			type: Number,
 			required: true
+		},
+		maxParticipants: {
+			type: Number,
+			required: false
 		},
 		autoDeletionDate: {
 			type: Number,

--- a/meet-ce/backend/src/models/zod-schemas/room.schema.ts
+++ b/meet-ce/backend/src/models/zod-schemas/room.schema.ts
@@ -16,13 +16,17 @@ import {
 	MeetRoomDeletionPolicyWithMeeting,
 	MeetRoomDeletionPolicyWithRecordings,
 	MeetRoomFilters,
+	MeetRoomMediaConfig,
+	MeetRoomMediaMode,
 	MeetRoomMemberRole,
 	MeetRoomMemberTokenMetadata,
 	MeetRoomMemberTokenOptions,
 	MeetRoomOptions,
+	MeetRoomScreenShareConfig,
 	MeetRoomStatus,
 	MeetRoomTheme,
 	MeetRoomThemeMode,
+	MeetScreenShareAccess,
 	MeetVirtualBackgroundConfig
 } from '@openvidu-meet/typings';
 import ms from 'ms';
@@ -175,6 +179,14 @@ const CaptionsConfigSchema: z.ZodType<MeetRoomCaptionsConfig> = z.object({
 	enabled: z.boolean()
 });
 
+const MediaConfigSchema: z.ZodType<MeetRoomMediaConfig> = z.object({
+	mode: z.nativeEnum(MeetRoomMediaMode)
+});
+
+const ScreenShareConfigSchema: z.ZodType<MeetRoomScreenShareConfig> = z.object({
+	allowAccessTo: z.nativeEnum(MeetScreenShareAccess)
+});
+
 const ThemeModeSchema: z.ZodType<MeetRoomThemeMode> = z.nativeEnum(MeetRoomThemeMode);
 
 const hexColorSchema = z
@@ -213,7 +225,9 @@ const UpdateRoomConfigSchema: z.ZodType<Partial<MeetRoomConfig>> = z
 		chat: ChatConfigSchema.optional(),
 		virtualBackground: VirtualBackgroundConfigSchema.optional(),
 		e2ee: E2EEConfigSchema.optional(),
-		captions: CaptionsConfigSchema.optional()
+		captions: CaptionsConfigSchema.optional(),
+		media: MediaConfigSchema.optional(),
+		screenShare: ScreenShareConfigSchema.optional()
 		// appearance: AppearanceConfigSchema,
 	})
 	.transform((data: Partial<MeetRoomConfig>) => {
@@ -246,7 +260,11 @@ const CreateRoomConfigSchema = z
 		chat: ChatConfigSchema.optional().default(() => ({ enabled: true })),
 		virtualBackground: VirtualBackgroundConfigSchema.optional().default(() => ({ enabled: true })),
 		e2ee: E2EEConfigSchema.optional().default(() => ({ enabled: false })),
-		captions: CaptionsConfigSchema.optional().default(() => ({ enabled: true }))
+		captions: CaptionsConfigSchema.optional().default(() => ({ enabled: true })),
+		media: MediaConfigSchema.optional().default(() => ({ mode: MeetRoomMediaMode.STANDARD })),
+		screenShare: ScreenShareConfigSchema.optional().default(() => ({
+			allowAccessTo: MeetScreenShareAccess.ADMIN_MODERATOR_SPEAKER
+		}))
 		// appearance: AppearanceConfigSchema,
 	})
 	.transform((data) => {
@@ -296,6 +314,12 @@ export const RoomOptionsSchema: z.ZodType<MeetRoomOptions> = z.object({
 		.transform(MeetRoomHelper.sanitizeRoomName)
 		.optional()
 		.default('Room'),
+	passcode: z
+		.string()
+		.trim()
+		.regex(/^[a-zA-Z0-9]{8}$/, 'passcode must be an 8 character alphanumeric string')
+		.transform((value) => value.toUpperCase())
+		.optional(),
 	autoDeletionDate: z
 		.number()
 		.positive('autoDeletionDate must be a positive integer')
@@ -337,14 +361,15 @@ export const RoomOptionsSchema: z.ZodType<MeetRoomOptions> = z.object({
 		chat: { enabled: true },
 		virtualBackground: { enabled: true },
 		e2ee: { enabled: false },
-		captions: { enabled: true }
-	})
-	// maxParticipants: z
-	// 	.number()
-	// 	.positive('Max participants must be a positive integer')
-	// 	.nullable()
-	// 	.optional()
-	// 	.default(null)
+		captions: { enabled: true },
+		media: { mode: MeetRoomMediaMode.STANDARD },
+		screenShare: { allowAccessTo: MeetScreenShareAccess.ADMIN_MODERATOR_SPEAKER }
+	}),
+	maxParticipants: z
+		.number()
+		.int('maxParticipants must be an integer')
+		.positive('maxParticipants must be a positive integer')
+		.optional()
 });
 
 export const RoomFiltersSchema: z.ZodType<MeetRoomFilters> = z.object({
@@ -423,7 +448,13 @@ export const RoomMemberTokenOptionsSchema: z.ZodType<MeetRoomMemberTokenOptions>
 		secret: z.string().nonempty('Secret is required'),
 		grantJoinMeetingPermission: z.boolean().optional().default(false),
 		participantName: z.string().optional(),
-		participantIdentity: z.string().optional()
+		participantIdentity: z.string().optional(),
+		captchaToken: z.string().optional(),
+		roomPasscode: z
+			.string()
+			.trim()
+			.transform((value) => value.toUpperCase())
+			.optional()
 	})
 	.refine(
 		(data) => {

--- a/meet-ce/backend/src/repositories/room.repository.ts
+++ b/meet-ce/backend/src/repositories/room.repository.ts
@@ -70,6 +70,18 @@ export class RoomRepository<TRoom extends MeetRoom = MeetRoom> extends BaseRepos
 	}
 
 	/**
+	 * Finds a room by its passcode.
+	 *
+	 * @param passcode - The room passcode
+	 * @param fields - Optional comma-separated list of fields to include in the result
+	 * @returns The room or null if not found
+	 */
+	async findByPasscode(passcode: string, fields?: string): Promise<TRoom | null> {
+		const document = await this.findOne({ passcode }, fields);
+		return document ? this.enrichRoomWithBaseUrls(document) : null;
+	}
+
+	/**
 	 * Finds rooms with optional filtering, pagination, and sorting.
 	 * Returns rooms with enriched URLs (including base URL).
 	 *

--- a/meet-ce/backend/src/routes/global-config.routes.ts
+++ b/meet-ce/backend/src/routes/global-config.routes.ts
@@ -44,3 +44,6 @@ configRouter.get('/rooms/appearance', withAuth(allowAnonymous), globalConfigCtrl
 
 // Captions config
 configRouter.get('/captions', withAuth(allowAnonymous), globalConfigCtrl.getCaptionsConfig);
+
+// Guest captcha config
+configRouter.get('/captcha/guest', withAuth(allowAnonymous), globalConfigCtrl.getGuestCaptchaConfig);

--- a/meet-ce/backend/src/routes/room.routes.ts
+++ b/meet-ce/backend/src/routes/room.routes.ts
@@ -9,6 +9,7 @@ import {
 	tokenAndRoleValidator,
 	withAuth
 } from '../middlewares/auth.middleware.js';
+import { validateGuestCaptcha } from '../middlewares/captcha.middleware.js';
 import { configureRoomMemberTokenAuth } from '../middlewares/participant.middleware.js';
 import {
 	validateBulkDeleteRoomsReq,
@@ -93,6 +94,7 @@ internalRoomRouter.post(
 	withValidRoomId,
 	validateCreateRoomMemberTokenReq,
 	configureRoomMemberTokenAuth,
+	validateGuestCaptcha,
 	roomCtrl.generateRoomMemberToken
 );
 internalRoomRouter.get(

--- a/meet-ce/backend/src/services/captcha.service.ts
+++ b/meet-ce/backend/src/services/captcha.service.ts
@@ -1,0 +1,94 @@
+import { GuestCaptchaConfig } from '@openvidu-meet/typings';
+import { inject, injectable } from 'inversify';
+import { MEET_ENV } from '../environment.js';
+import {
+	errorCaptchaNotConfigured,
+	errorCaptchaTokenRequired,
+	errorCaptchaValidationFailed,
+	internalError
+} from '../models/error.model.js';
+import { LoggerService } from './logger.service.js';
+
+interface RecaptchaVerifyResponse {
+	success: boolean;
+	'h-score'?: number;
+	action?: string;
+	'error-codes'?: string[];
+}
+
+@injectable()
+export class CaptchaService {
+	constructor(@inject(LoggerService) private logger: LoggerService) {}
+
+	isGuestCaptchaEnabled(): boolean {
+		return MEET_ENV.GUEST_CAPTCHA_ENABLED.toLowerCase() === 'true';
+	}
+
+	getGuestCaptchaConfig(): GuestCaptchaConfig {
+		return {
+			enabled: this.isGuestCaptchaEnabled(),
+			provider: 'recaptcha-v2',
+			siteKey: MEET_ENV.GUEST_CAPTCHA_SITE_KEY || undefined
+		};
+	}
+
+	async validateGuestCaptcha(token?: string, remoteIp?: string | string[]): Promise<void> {
+		if (!this.isGuestCaptchaEnabled()) {
+			return;
+		}
+
+		if (!token) {
+			throw errorCaptchaTokenRequired();
+		}
+
+		const secret = MEET_ENV.GUEST_CAPTCHA_SECRET_KEY;
+		if (!secret) {
+			this.logger.error('Captcha secret key is not configured but captcha is enabled');
+			throw errorCaptchaNotConfigured();
+		}
+
+		const payload = new URLSearchParams();
+		payload.append('secret', secret);
+		payload.append('response', token);
+
+		const clientIp = this.extractClientIp(remoteIp);
+		if (clientIp) {
+			payload.append('remoteip', clientIp);
+		}
+
+		let response: Awaited<ReturnType<typeof fetch>>;
+		try {
+			response = await fetch('https://www.google.com/recaptcha/api/siteverify', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded'
+				},
+				body: payload.toString()
+			});
+		} catch (error) {
+			this.logger.error('Error calling reCAPTCHA verification endpoint', error);
+			throw internalError('verifying captcha token');
+		}
+
+		if (!response.ok) {
+			this.logger.error(`reCAPTCHA verification responded with HTTP ${response.status}`);
+			throw internalError('verifying captcha token');
+		}
+
+		const result = (await response.json()) as RecaptchaVerifyResponse;
+		if (!result.success) {
+			this.logger.warn('Captcha verification failed', result['error-codes']);
+			throw errorCaptchaValidationFailed();
+		}
+	}
+
+	private extractClientIp(remoteIp?: string | string[]): string | undefined {
+		if (!remoteIp) {
+			return undefined;
+		}
+
+		const rawIp = Array.isArray(remoteIp) ? remoteIp[0] : remoteIp;
+		const candidate = rawIp.split(',')[0]?.trim();
+		return candidate || undefined;
+	}
+}

--- a/meet-ce/backend/src/services/livekit.service.ts
+++ b/meet-ce/backend/src/services/livekit.service.ts
@@ -1,4 +1,4 @@
-import { AgentDispatch, ParticipantInfo_Kind } from '@livekit/protocol';
+import { ParticipantInfo_Kind } from '@livekit/protocol';
 import { inject, injectable } from 'inversify';
 import {
 	AgentDispatchClient,
@@ -27,6 +27,9 @@ import {
 } from '../models/error.model.js';
 import { chunkArray } from '../utils/array.utils.js';
 import { LoggerService } from './logger.service.js';
+
+type LiveKitAgentDispatch = Awaited<ReturnType<AgentDispatchClient['createDispatch']>>;
+type LiveKitAgentDispatchList = Awaited<ReturnType<AgentDispatchClient['listDispatch']>>;
 
 @injectable()
 export class LiveKitService {
@@ -286,7 +289,7 @@ export class LiveKitService {
 	async createAgent(
 		roomName: string,
 		agentName: string /*, options: CreateDispatchOptions*/
-	): Promise<AgentDispatch> {
+	): Promise<LiveKitAgentDispatch> {
 		try {
 			return await this.agentClient.createDispatch(roomName, agentName);
 		} catch (error) {
@@ -300,7 +303,7 @@ export class LiveKitService {
 	 * @param roomName
 	 * @returns An array of agents in the specified room
 	 */
-	async listAgents(roomName: string): Promise<AgentDispatch[]> {
+	async listAgents(roomName: string): Promise<LiveKitAgentDispatchList> {
 		try {
 			return await this.agentClient.listDispatch(roomName);
 		} catch (error) {
@@ -315,7 +318,7 @@ export class LiveKitService {
 	 * @param agentId
 	 * @returns The agent if found, otherwise undefined
 	 */
-	async getAgent(roomName: string, agentId: string): Promise<AgentDispatch | undefined> {
+	async getAgent(roomName: string, agentId: string): Promise<LiveKitAgentDispatch | undefined> {
 		try {
 			return await this.agentClient.getDispatch(agentId, roomName);
 		} catch (error) {

--- a/meet-ce/backend/src/services/room-member.service.ts
+++ b/meet-ce/backend/src/services/room-member.service.ts
@@ -1,17 +1,26 @@
 import {
 	MeetRecordingAccess,
+	MeetRoomMediaMode,
 	MeetRoomMemberPermissions,
 	MeetRoomMemberRole,
 	MeetRoomMemberTokenMetadata,
 	MeetRoomMemberTokenOptions,
-	MeetRoomStatus
+	MeetRoomStatus,
+	MeetScreenShareAccess,
+	TrackSource
 } from '@openvidu-meet/typings';
 import { inject, injectable } from 'inversify';
 import { ParticipantInfo } from 'livekit-server-sdk';
 import { uid } from 'uid/single';
 import { MeetRoomHelper } from '../helpers/room.helper.js';
 import { validateRoomMemberTokenMetadata } from '../middlewares/request-validators/room-validator.middleware.js';
-import { errorInvalidRoomSecret, errorParticipantNotFound, errorRoomClosed } from '../models/error.model.js';
+import {
+	errorInvalidRoomPasscode,
+	errorInvalidRoomSecret,
+	errorParticipantNotFound,
+	errorRoomClosed,
+	errorRoomMaxParticipantsReached
+} from '../models/error.model.js';
 import { FrontendEventService } from './frontend-event.service.js';
 import { LiveKitService } from './livekit.service.js';
 import { LoggerService } from './logger.service.js';
@@ -64,7 +73,17 @@ export class RoomMemberService {
 	 * @returns A promise that resolves to the generated token
 	 */
 	async generateOrRefreshRoomMemberToken(roomId: string, tokenOptions: MeetRoomMemberTokenOptions): Promise<string> {
-		const { secret, grantJoinMeetingPermission = false, participantName, participantIdentity } = tokenOptions;
+		const {
+			secret,
+			grantJoinMeetingPermission = false,
+			participantName,
+			participantIdentity,
+			roomPasscode
+		} = tokenOptions;
+
+		if (grantJoinMeetingPermission) {
+			await this.validateRoomPasscode(roomId, roomPasscode);
+		}
 
 		// Get room member role from secret
 		const role = await this.getRoomMemberRoleBySecret(roomId, secret);
@@ -73,6 +92,19 @@ export class RoomMemberService {
 			return this.generateTokenWithJoinMeetingPermission(roomId, role, participantName, participantIdentity);
 		} else {
 			return this.generateTokenWithoutJoinMeetingPermission(roomId, role);
+		}
+	}
+
+	private async validateRoomPasscode(roomId: string, roomPasscode?: string): Promise<void> {
+		const room = await this.roomService.getMeetRoom(roomId, 'roomId,passcode');
+
+		if (!room.passcode) {
+			return;
+		}
+
+		const normalizedInput = roomPasscode ? MeetRoomHelper.sanitizeRoomPasscode(roomPasscode) : '';
+		if (normalizedInput !== room.passcode) {
+			throw errorInvalidRoomPasscode(roomId);
 		}
 	}
 
@@ -103,6 +135,13 @@ export class RoomMemberService {
 
 			// Create the Livekit room if it doesn't exist
 			await this.roomService.createLivekitRoom(roomId);
+
+			if (typeof room.maxParticipants === 'number' && room.maxParticipants > 0) {
+				const participants = await this.livekitService.listRoomParticipants(roomId);
+				if (participants.length >= room.maxParticipants) {
+					throw errorRoomMaxParticipantsReached(roomId, room.maxParticipants);
+				}
+			}
 
 			try {
 				// Reserve a unique name for the participant
@@ -169,11 +208,17 @@ export class RoomMemberService {
 		addJoinPermission = true
 	): Promise<MeetRoomMemberPermissions> {
 		const recordingPermissions = await this.getRecordingPermissions(roomId, role);
+		const room = await this.roomService.getMeetRoom(roomId, 'config');
+		const roomMediaMode = room.config.media?.mode || MeetRoomMediaMode.STANDARD;
+		const screenShareAccess =
+			room.config.screenShare?.allowAccessTo || MeetScreenShareAccess.ADMIN_MODERATOR_SPEAKER;
 
 		switch (role) {
 			case MeetRoomMemberRole.MODERATOR:
 				return this.generateModeratorPermissions(
 					roomId,
+					roomMediaMode,
+					screenShareAccess,
 					recordingPermissions.canRetrieveRecordings,
 					recordingPermissions.canDeleteRecordings,
 					addJoinPermission
@@ -181,6 +226,8 @@ export class RoomMemberService {
 			case MeetRoomMemberRole.SPEAKER:
 				return this.generateSpeakerPermissions(
 					roomId,
+					roomMediaMode,
+					screenShareAccess,
 					recordingPermissions.canRetrieveRecordings,
 					recordingPermissions.canDeleteRecordings,
 					addJoinPermission
@@ -190,15 +237,24 @@ export class RoomMemberService {
 
 	protected generateModeratorPermissions(
 		roomId: string,
+		roomMediaMode: MeetRoomMediaMode,
+		screenShareAccess: MeetScreenShareAccess,
 		canRetrieveRecordings: boolean,
 		canDeleteRecordings: boolean,
 		addJoinPermission: boolean
 	): MeetRoomMemberPermissions {
+		const canPublishSources = this.getAllowedPublishSources(
+			roomMediaMode,
+			screenShareAccess,
+			MeetRoomMemberRole.MODERATOR
+		);
+
 		return {
 			livekit: {
 				roomJoin: addJoinPermission,
 				room: roomId,
 				canPublish: true,
+				canPublishSources,
 				canSubscribe: true,
 				canPublishData: true,
 				canUpdateOwnMetadata: true
@@ -215,15 +271,24 @@ export class RoomMemberService {
 
 	protected generateSpeakerPermissions(
 		roomId: string,
+		roomMediaMode: MeetRoomMediaMode,
+		screenShareAccess: MeetScreenShareAccess,
 		canRetrieveRecordings: boolean,
 		canDeleteRecordings: boolean,
 		addJoinPermission: boolean
 	): MeetRoomMemberPermissions {
+		const canPublishSources = this.getAllowedPublishSources(
+			roomMediaMode,
+			screenShareAccess,
+			MeetRoomMemberRole.SPEAKER
+		);
+
 		return {
 			livekit: {
 				roomJoin: addJoinPermission,
 				room: roomId,
 				canPublish: true,
+				canPublishSources,
 				canSubscribe: true,
 				canPublishData: true,
 				canUpdateOwnMetadata: true
@@ -236,6 +301,40 @@ export class RoomMemberService {
 				canChangeVirtualBackground: true
 			}
 		};
+	}
+
+	protected getAllowedPublishSources(
+		roomMediaMode: MeetRoomMediaMode,
+		screenShareAccess: MeetScreenShareAccess,
+		role: MeetRoomMemberRole
+	): TrackSource[] {
+		const sources: TrackSource[] = [TrackSource.MICROPHONE];
+
+		if (roomMediaMode !== MeetRoomMediaMode.AUDIO_ONLY && roomMediaMode !== MeetRoomMediaMode.VIDEO_DISABLED) {
+			sources.push(TrackSource.CAMERA);
+		}
+
+		if (
+			roomMediaMode !== MeetRoomMediaMode.AUDIO_ONLY &&
+			this.isScreenShareAllowedForRole(screenShareAccess, role)
+		) {
+			sources.push(TrackSource.SCREEN_SHARE, TrackSource.SCREEN_SHARE_AUDIO);
+		}
+
+		return sources;
+	}
+
+	protected isScreenShareAllowedForRole(screenShareAccess: MeetScreenShareAccess, role: MeetRoomMemberRole): boolean {
+		switch (screenShareAccess) {
+			case MeetScreenShareAccess.ADMIN:
+				return role === MeetRoomMemberRole.MODERATOR;
+			case MeetScreenShareAccess.ADMIN_MODERATOR:
+				return role === MeetRoomMemberRole.MODERATOR;
+			case MeetScreenShareAccess.ADMIN_MODERATOR_SPEAKER:
+				return role === MeetRoomMemberRole.MODERATOR || role === MeetRoomMemberRole.SPEAKER;
+			default:
+				return false;
+		}
 	}
 
 	protected async getRecordingPermissions(

--- a/meet-ce/backend/src/services/room.service.ts
+++ b/meet-ce/backend/src/services/room.service.ts
@@ -34,7 +34,6 @@ import { LoggerService } from './logger.service.js';
 import { RecordingService } from './recording.service.js';
 import { RequestSessionService } from './request-session.service.js';
 
-
 /**
  * Service for managing OpenVidu Meet rooms.
  *
@@ -62,18 +61,20 @@ export class RoomService {
 	 *
 	 */
 	async createMeetRoom(roomOptions: MeetRoomOptions): Promise<MeetRoom> {
-		const { roomName, autoDeletionDate, autoDeletionPolicy, config } = roomOptions;
+		const { roomName, passcode, maxParticipants, autoDeletionDate, autoDeletionPolicy, config } = roomOptions;
 
 		// Generate a unique room ID based on the room name
 		const roomIdPrefix = MeetRoomHelper.createRoomIdPrefixFromRoomName(roomName!) || 'room';
 		const roomId = `${roomIdPrefix}-${uid(15)}`;
 		const roomConfig: MeetRoomConfig = config as MeetRoomConfig;
+		const roomPasscode = await this.resolveUniqueRoomPasscode(passcode);
 
 		const meetRoom: MeetRoom = {
 			roomId,
 			roomName: roomName!,
+			passcode: roomPasscode,
 			creationDate: Date.now(),
-			// maxParticipants,
+			maxParticipants,
 			autoDeletionDate,
 			autoDeletionPolicy,
 			config: roomConfig,
@@ -83,6 +84,30 @@ export class RoomService {
 			meetingEndAction: MeetingEndAction.NONE
 		};
 		return await this.roomRepository.create(meetRoom);
+	}
+
+	private async resolveUniqueRoomPasscode(inputPasscode?: string): Promise<string> {
+		const maxAttempts = 20;
+		let attempts = 0;
+
+		const firstCandidate = inputPasscode
+			? MeetRoomHelper.sanitizeRoomPasscode(inputPasscode)
+			: MeetRoomHelper.createRoomPasscode();
+
+		let candidate = firstCandidate;
+
+		while (attempts < maxAttempts) {
+			const existingRoom = await this.roomRepository.findByPasscode(candidate, 'roomId');
+
+			if (!existingRoom) {
+				return candidate;
+			}
+
+			candidate = MeetRoomHelper.createRoomPasscode();
+			attempts += 1;
+		}
+
+		throw internalError('generating a unique room passcode');
 	}
 
 	/**
@@ -108,8 +133,8 @@ export class RoomService {
 				roomOptions: MeetRoomHelper.toOpenViduOptions(meetRoom)
 			}),
 			emptyTimeout: MEETING_EMPTY_TIMEOUT ? ms(MEETING_EMPTY_TIMEOUT) / 1000 : undefined,
-			departureTimeout: MEETING_DEPARTURE_TIMEOUT ? ms(MEETING_DEPARTURE_TIMEOUT) / 1000 : undefined
-			// maxParticipants: maxParticipants || undefined,
+			departureTimeout: MEETING_DEPARTURE_TIMEOUT ? ms(MEETING_DEPARTURE_TIMEOUT) / 1000 : undefined,
+			maxParticipants: meetRoom.maxParticipants
 		};
 
 		const room = await this.livekitService.createRoom(livekitRoomOptions);

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/components/meeting-lobby/meeting-lobby.component.html
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/components/meeting-lobby/meeting-lobby.component.html
@@ -30,9 +30,9 @@
 					</div>
 				</mat-card-header>
 
-			<mat-card-content class="card-content">
-				@if (!roomClosed()) {
-					<form [formGroup]="participantForm()" (ngSubmit)="onFormSubmit()" class="join-form">
+				<mat-card-content class="card-content">
+					@if (!roomClosed()) {
+						<form [formGroup]="participantForm()" (ngSubmit)="onFormSubmit()" class="join-form">
 							<!-- Participant Name Input -->
 							<mat-form-field appearance="outline" class="name-field">
 								<mat-label>Your display name</mat-label>
@@ -49,6 +49,26 @@
 								}
 							</mat-form-field>
 
+							@if (roomRequiresPasscode()) {
+								<mat-form-field appearance="outline" class="name-field fade-in">
+									<mat-label>Meeting passcode</mat-label>
+									<input
+										id="participant-passcode-input"
+										matInput
+										placeholder="Enter room passcode"
+										formControlName="passcode"
+										required
+									/>
+									<mat-icon matSuffix class="ov-action-icon">password</mat-icon>
+									@if (participantForm().get('passcode')?.hasError('required')) {
+										<mat-error> The passcode is <strong>required</strong> </mat-error>
+									}
+									@if (participantForm().get('passcode')?.hasError('invalidPasscode')) {
+										<mat-error> Invalid passcode. Please verify it and try again. </mat-error>
+									}
+								</mat-form-field>
+							}
+
 							<!-- E2EE Key Input (shown when E2EE is enabled and key is not pre-filled from URL) -->
 							@if (showE2EEKeyInput()) {
 								<mat-form-field appearance="outline" class="e2eekey-field fade-in">
@@ -61,12 +81,23 @@
 										formControlName="e2eeKey"
 										required
 									/>
-								<mat-icon matSuffix class="ov-action-icon">vpn_key</mat-icon>
-								@if (participantForm().get('e2eeKey')?.hasError('required')) {
-									<mat-error> The encryption key is <strong>required</strong> </mat-error>
-								}
+									<mat-icon matSuffix class="ov-action-icon">vpn_key</mat-icon>
+									@if (participantForm().get('e2eeKey')?.hasError('required')) {
+										<mat-error> The encryption key is <strong>required</strong> </mat-error>
+									}
 									<mat-hint>This room requires an encryption key to join</mat-hint>
 								</mat-form-field>
+							}
+
+							@if (isGuestCaptchaEnabled()) {
+								<div class="captcha-wrapper fade-in">
+									<div #captchaContainer class="captcha-container"></div>
+									@if (captchaMissing()) {
+										<div class="captcha-error">
+											Please complete the captcha challenge to continue.
+										</div>
+									}
+								</div>
 							}
 
 							<button
@@ -75,7 +106,7 @@
 								id="participant-name-submit"
 								type="submit"
 								class="join-button"
-								[disabled]="!participantForm().valid"
+								[disabled]="!participantForm().valid || captchaMissing()"
 							>
 								<span>Join Meeting</span>
 							</button>
@@ -127,7 +158,11 @@
 
 		<!-- Room URL Badge -->
 		@if (!roomClosed() && showShareLink()) {
-			<ov-share-meeting-link [meetingUrl]="meetingUrl()" (copyClicked)="onCopyLinkClick()"></ov-share-meeting-link>
+			<ov-share-meeting-link
+				[meetingUrl]="meetingUrl()"
+				[additionalInfo]="passcodeInfo()"
+				(copyClicked)="onCopyLinkClick()"
+			></ov-share-meeting-link>
 		}
 
 		<!-- Quick Actions -->

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/components/meeting-lobby/meeting-lobby.component.scss
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/components/meeting-lobby/meeting-lobby.component.scss
@@ -227,6 +227,23 @@
 		animation: slideDown 0.3s ease-out;
 	}
 
+	.captcha-wrapper {
+		display: flex;
+		flex-direction: column;
+		gap: var(--ov-meet-spacing-xs);
+		align-items: flex-start;
+		margin: var(--ov-meet-spacing-xs) 0;
+	}
+
+	.captcha-container {
+		min-height: 78px;
+	}
+
+	.captcha-error {
+		font-size: var(--ov-meet-font-size-sm);
+		color: var(--ov-meet-color-error, #d32f2f);
+	}
+
 	.mat-mdc-form-field-icon-suffix {
 		color: var(--ov-meet-text-hint);
 	}

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/components/meeting-lobby/meeting-lobby.component.ts
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/components/meeting-lobby/meeting-lobby.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, computed, inject } from '@angular/core';
+import { Component, computed, effect, ElementRef, inject, signal, ViewChild } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -31,6 +31,17 @@ import { MeetingService } from '../../services/meeting.service';
 	]
 })
 export class MeetingLobbyComponent {
+	private readonly captchaContainerRef = signal<ElementRef<HTMLDivElement> | undefined>(undefined);
+
+	@ViewChild('captchaContainer')
+	set captchaContainer(value: ElementRef<HTMLDivElement> | undefined) {
+		this.captchaContainerRef.set(value);
+	}
+
+	private captchaWidgetId?: number;
+	private captchaRendered = false;
+	private static recaptchaScriptPromise?: Promise<void>;
+
 	protected lobbyService = inject(MeetingLobbyService);
 	protected meetingService = inject(MeetingService);
 
@@ -46,6 +57,15 @@ export class MeetingLobbyComponent {
 	protected showBackButton = computed(() => this.lobbyService.state().showBackButton);
 	protected backButtonText = computed(() => this.lobbyService.state().backButtonText);
 	protected isE2EEEnabled = computed(() => this.lobbyService.state().hasRoomE2EEEnabled);
+	protected roomRequiresPasscode = computed(() => this.lobbyService.roomRequiresPasscode());
+	protected roomPasscode = computed(() => this.lobbyService.roomPasscode());
+	protected passcodeInfo = computed(() => {
+		const passcode = this.roomPasscode();
+		return passcode ? `Passcode: ${passcode}` : undefined;
+	});
+	protected guestCaptchaConfig = computed(() => this.lobbyService.guestCaptchaConfig());
+	protected isGuestCaptchaEnabled = computed(() => this.lobbyService.guestCaptchaEnabled());
+	protected captchaToken = computed(() => this.lobbyService.captchaToken());
 	protected participantForm = computed(() => this.lobbyService.state().participantForm);
 	/**
 	 * Computed signal to determine if the E2EE key input should be shown.
@@ -57,7 +77,35 @@ export class MeetingLobbyComponent {
 		return this.isE2EEEnabled() && e2eeKeyControl?.enabled;
 	});
 
+	protected captchaMissing = computed(() => this.isGuestCaptchaEnabled() && !this.captchaToken());
+
+	constructor() {
+		effect(() => {
+			const container = this.captchaContainerRef();
+			console.debug('[captcha] effect triggered', {
+				enabled: this.isGuestCaptchaEnabled(),
+				hasContainer: !!container,
+				hasToken: !!this.captchaToken(),
+				config: this.guestCaptchaConfig()
+			});
+			if (this.isGuestCaptchaEnabled() && container) {
+				void this.renderCaptchaIfNeeded();
+			}
+		});
+	}
+
+	async ngAfterViewInit(): Promise<void> {
+		await this.renderCaptchaIfNeeded();
+	}
+
+	ngOnDestroy(): void {
+		this.resetCaptcha();
+	}
+
 	async onFormSubmit(): Promise<void> {
+		if (this.captchaMissing()) {
+			return;
+		}
 		await this.lobbyService.submitAccess();
 	}
 
@@ -71,5 +119,162 @@ export class MeetingLobbyComponent {
 
 	onCopyLinkClick(): void {
 		this.lobbyService.copyMeetingSpeakerLink();
+	}
+
+	protected async onCaptchaResolved(token: string): Promise<void> {
+		console.debug('[captcha] resolved token received', { hasToken: !!token, tokenLength: token?.length });
+		this.lobbyService.setCaptchaToken(token);
+	}
+
+	protected onCaptchaExpiredOrError(): void {
+		console.warn('[captcha] expired or error callback fired');
+		this.lobbyService.setCaptchaToken(undefined);
+	}
+
+	private async renderCaptchaIfNeeded(): Promise<void> {
+		const captchaContainer = this.captchaContainerRef();
+
+		if (!this.isGuestCaptchaEnabled() || this.captchaRendered || !captchaContainer?.nativeElement) {
+			console.debug('[captcha] skip render', {
+				enabled: this.isGuestCaptchaEnabled(),
+				alreadyRendered: this.captchaRendered,
+				hasContainer: !!captchaContainer?.nativeElement
+			});
+			return;
+		}
+
+		const siteKey = this.guestCaptchaConfig()?.siteKey;
+		if (!siteKey) {
+			console.warn('[captcha] site key missing, cannot render widget');
+			return;
+		}
+
+		console.debug('[captcha] attempting to render widget', { siteKeyPrefix: siteKey.slice(0, 8) });
+
+		try {
+			await this.loadRecaptchaScript();
+		} catch (error) {
+			console.warn('Failed to load reCAPTCHA script', error);
+			return;
+		}
+
+		if (!window.grecaptcha?.render) {
+			console.warn('[captcha] grecaptcha.render is unavailable after script load');
+			return;
+		}
+
+		this.captchaWidgetId = window.grecaptcha.render(captchaContainer.nativeElement, {
+			sitekey: siteKey,
+			callback: (token: string) => void this.onCaptchaResolved(token),
+			'expired-callback': () => this.onCaptchaExpiredOrError(),
+			'error-callback': () => this.onCaptchaExpiredOrError()
+		});
+
+		this.captchaRendered = true;
+		console.debug('[captcha] widget rendered', { widgetId: this.captchaWidgetId });
+	}
+
+	private resetCaptcha(): void {
+		if (this.captchaWidgetId !== undefined && window.grecaptcha?.reset) {
+			window.grecaptcha.reset(this.captchaWidgetId);
+		}
+		this.captchaRendered = false;
+		this.captchaWidgetId = undefined;
+		this.lobbyService.setCaptchaToken(undefined);
+	}
+
+	private loadRecaptchaScript(): Promise<void> {
+		if (window.grecaptcha?.render) {
+			console.debug('[captcha] script already loaded (grecaptcha available)');
+			return Promise.resolve();
+		}
+
+		if (MeetingLobbyComponent.recaptchaScriptPromise) {
+			console.debug('[captcha] reusing existing script loading promise');
+			return MeetingLobbyComponent.recaptchaScriptPromise;
+		}
+
+		MeetingLobbyComponent.recaptchaScriptPromise = new Promise<void>((resolve, reject) => {
+			const resolveWhenReady = () => {
+				this.waitForGrecaptchaReady()
+					.then(() => resolve())
+					.catch((error) => reject(error));
+			};
+
+			const existing = document.getElementById('ov-recaptcha-script') as HTMLScriptElement | null;
+
+			if (existing) {
+				console.debug('[captcha] script tag already exists, waiting for load event');
+				resolveWhenReady();
+				existing.addEventListener('load', () => resolveWhenReady(), { once: true });
+				existing.addEventListener('error', () => reject(new Error('Failed to load reCAPTCHA script')), {
+					once: true
+				});
+				return;
+			}
+
+			const tryLoad = (src: string, scriptId: string, fallback?: () => void) => {
+				console.debug('[captcha] loading script', { src, scriptId });
+				const script = document.createElement('script');
+				script.id = scriptId;
+				script.src = src;
+				script.async = true;
+				script.defer = true;
+				script.onload = () => {
+					console.debug('[captcha] script loaded successfully', { src });
+					resolveWhenReady();
+				};
+				script.onerror = () => {
+					console.warn('[captcha] script load failed', { src });
+					script.remove();
+					if (fallback) {
+						fallback();
+					} else {
+						reject(new Error('Failed to load reCAPTCHA script'));
+					}
+				};
+
+				document.head.appendChild(script);
+			};
+
+			tryLoad('https://www.google.com/recaptcha/api.js?render=explicit', 'ov-recaptcha-script', () =>
+				tryLoad('https://www.recaptcha.net/recaptcha/api.js?render=explicit', 'ov-recaptcha-script-fallback')
+			);
+		});
+
+		return MeetingLobbyComponent.recaptchaScriptPromise;
+	}
+
+	private waitForGrecaptchaReady(maxAttempts = 20, delayMs = 150): Promise<void> {
+		return new Promise((resolve, reject) => {
+			let attempts = 0;
+
+			const tick = () => {
+				if (window.grecaptcha?.render) {
+					console.debug('[captcha] grecaptcha ready');
+					resolve();
+					return;
+				}
+
+				attempts += 1;
+				if (attempts >= maxAttempts) {
+					reject(new Error('reCAPTCHA API loaded but grecaptcha is not available'));
+					return;
+				}
+
+				setTimeout(tick, delayMs);
+			};
+
+			tick();
+		});
+	}
+}
+
+declare global {
+	interface Window {
+		grecaptcha?: {
+			render: (container: HTMLElement, parameters: Record<string, unknown>) => number;
+			reset: (widgetId?: number) => void;
+		};
 	}
 }

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/components/meeting-share-link-overlay/meeting-share-link-overlay.component.html
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/components/meeting-share-link-overlay/meeting-share-link-overlay.component.html
@@ -7,6 +7,7 @@
 			[titleSize]="titleSize"
 			[titleWeight]="titleWeight"
 			[meetingUrl]="meetingUrl"
+			[additionalInfo]="passcodeInfo"
 			(copyClicked)="onCopyClicked()"
 		></ov-share-meeting-link>
 	</div>

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/components/meeting-share-link-overlay/meeting-share-link-overlay.component.ts
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/components/meeting-share-link-overlay/meeting-share-link-overlay.component.ts
@@ -22,6 +22,7 @@ export class MeetingShareLinkOverlayComponent {
 	 * The meeting URL to share
 	 */
 	@Input({ required: true }) meetingUrl = '';
+	@Input() passcodeInfo?: string;
 
 	/**
 	 * Title text for the overlay

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/components/share-meeting-link/share-meeting-link.component.html
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/components/share-meeting-link/share-meeting-link.component.html
@@ -10,13 +10,15 @@
 	}
 
 	<div class="meeting-url-badge-container" (click)="copyClicked.emit()">
-		<span class="meeting-url-text">{{ meetingUrl }}</span>
-		<button matIconButton class="copy-url-btn" matTooltip="Copy meeting link">
-			<mat-icon>content_copy</mat-icon>
-		</button>
-	</div>
+		<div class="meeting-url-row">
+			<span class="meeting-url-text">{{ meetingUrl }}</span>
+			<button matIconButton class="copy-url-btn" matTooltip="Copy meeting link">
+				<mat-icon>content_copy</mat-icon>
+			</button>
+		</div>
 
-	@if (additionalInfo) {
-		<div class="meeting-url-badge-additional-info">{{ additionalInfo }}</div>
-	}
+		@if (additionalInfo) {
+			<div class="meeting-url-additional-info">{{ additionalInfo }}</div>
+		}
+	</div>
 </div>

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/components/share-meeting-link/share-meeting-link.component.scss
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/components/share-meeting-link/share-meeting-link.component.scss
@@ -43,9 +43,11 @@
 		margin: var(--ov-meet-spacing-sm);
 	}
 	.meeting-url-badge-container {
-		@include design-tokens.ov-flex-center;
+		display: flex;
+		flex-direction: column;
+		align-items: stretch;
 		@include design-tokens.ov-theme-transition;
-		gap: var(--ov-meet-spacing-sm);
+		gap: var(--ov-meet-spacing-xs);
 		padding: var(--ov-meet-spacing-sm) var(--ov-meet-spacing-md);
 		background-color: var(--ov-surface-color); // Use ov-components variable
 		border: 1px solid var(--ov-meet-border-color-light);
@@ -54,6 +56,11 @@
 		max-width: fit-content;
 		margin: auto;
 		cursor: pointer;
+
+		.meeting-url-row {
+			@include design-tokens.ov-flex-center;
+			gap: var(--ov-meet-spacing-sm);
+		}
 
 		.meeting-url-text {
 			font-family: var(--ov-meet-font-family-mono, 'Roboto Mono', monospace);
@@ -91,6 +98,14 @@
 				background-color: var(--ov-hover-color);
 				color: var(--ov-text-surface-color);
 			}
+		}
+
+		.meeting-url-additional-info {
+			font-size: var(--ov-meet-font-size-sm);
+			font-weight: var(--ov-meet-font-weight-medium);
+			text-align: left;
+			color: var(--ov-text-surface-color);
+			word-break: break-word;
 		}
 	}
 }

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/customization/meeting-custom-layout/meeting-custom-layout.component.html
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/customization/meeting-custom-layout/meeting-custom-layout.component.html
@@ -14,6 +14,7 @@
 							[titleSize]="linkOverlayConfig.titleSize"
 							[titleWeight]="linkOverlayConfig.titleWeight"
 							[meetingUrl]="meetingUrl()"
+							[additionalInfo]="passcodeInfo()"
 							(copyClicked)="onCopyMeetingLinkClicked()"
 						></ov-share-meeting-link>
 					</div>

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/customization/meeting-custom-layout/meeting-custom-layout.component.ts
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/customization/meeting-custom-layout/meeting-custom-layout.component.ts
@@ -44,6 +44,10 @@ export class MeetingCustomLayoutComponent {
 	};
 
 	protected readonly meetingUrl = computed(() => this.meetingContextService.meetingUrl());
+	protected readonly passcodeInfo = computed(() => {
+		const passcode = this.meetingContextService.meetRoom()?.passcode;
+		return passcode ? `Passcode: ${passcode}` : undefined;
+	});
 	protected readonly remoteParticipants = computed(() => this.meetingContextService.remoteParticipants());
 	protected readonly shouldShowLinkOverlay = computed(() => {
 		const hasNoRemotes = this.meetingContextService.remoteParticipants().length === 0;

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/customization/meeting-invite-panel/meeting-invite-panel.component.html
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/customization/meeting-invite-panel/meeting-invite-panel.component.html
@@ -1,5 +1,9 @@
 @if (showShareLink()) {
 	<div class="share-meeting-link-container">
-		<ov-share-meeting-link [meetingUrl]="meetingUrl()" (copyClicked)="onCopyClicked()"></ov-share-meeting-link>
+		<ov-share-meeting-link
+			[meetingUrl]="meetingUrl()"
+			[additionalInfo]="passcodeInfo()"
+			(copyClicked)="onCopyClicked()"
+		></ov-share-meeting-link>
 	</div>
 }

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/customization/meeting-invite-panel/meeting-invite-panel.component.ts
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/customization/meeting-invite-panel/meeting-invite-panel.component.ts
@@ -35,6 +35,11 @@ export class MeetingInvitePanelComponent {
 		return this.meetingContextService.meetingUrl();
 	});
 
+	protected passcodeInfo = computed(() => {
+		const passcode = this.meetingContextService.meetRoom()?.passcode;
+		return passcode ? `Passcode: ${passcode}` : undefined;
+	});
+
 	onCopyClicked(): void {
 		const room = this.meetingContextService.meetRoom();
 		if (!room) {

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/models/lobby.model.ts
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/models/lobby.model.ts
@@ -1,5 +1,5 @@
 import { FormGroup } from '@angular/forms';
-import { MeetRoom } from '@openvidu-meet/typings';
+import { GuestCaptchaConfig, MeetRoom } from '@openvidu-meet/typings';
 
 /**
  * State interface representing the lobby phase of a meeting.
@@ -15,6 +15,8 @@ export interface LobbyState {
 	showBackButton: boolean;
 	backButtonText: string;
 	hasRoomE2EEEnabled: boolean;
+	guestCaptchaConfig?: GuestCaptchaConfig;
+	captchaToken?: string;
 	participantForm: FormGroup;
 	roomMemberToken?: string;
 }

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/services/meeting-lobby.service.ts
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/services/meeting-lobby.service.ts
@@ -5,6 +5,7 @@ import { MeetRoomStatus } from '@openvidu-meet/typings';
 import { LoggerService } from 'openvidu-components-angular';
 import { NavigationErrorReason } from '../../../shared/models/navigation.model';
 import { AppDataService } from '../../../shared/services/app-data.service';
+import { GlobalConfigService } from '../../../shared/services/global-config.service';
 import { NavigationService } from '../../../shared/services/navigation.service';
 import { AuthService } from '../../auth/services/auth.service';
 import { RecordingService } from '../../recordings/services/recording.service';
@@ -34,8 +35,11 @@ export class MeetingLobbyService {
 		showBackButton: true,
 		backButtonText: 'Back',
 		hasRoomE2EEEnabled: false,
+		guestCaptchaConfig: undefined,
+		captchaToken: undefined,
 		participantForm: new FormGroup({
 			name: new FormControl('', [Validators.required]),
+			passcode: new FormControl(''),
 			e2eeKey: new FormControl('')
 		}),
 		roomMemberToken: undefined
@@ -49,6 +53,7 @@ export class MeetingLobbyService {
 	protected roomMemberService: RoomMemberService = inject(RoomMemberService);
 	protected navigationService: NavigationService = inject(NavigationService);
 	protected appDataService: AppDataService = inject(AppDataService);
+	protected globalConfigService: GlobalConfigService = inject(GlobalConfigService);
 	protected wcManagerService: MeetingWebComponentManagerService = inject(MeetingWebComponentManagerService);
 	protected loggerService = inject(LoggerService);
 	protected log = this.loggerService.get('OpenVidu Meet - MeetingLobbyService');
@@ -116,6 +121,19 @@ export class MeetingLobbyService {
 	 */
 	readonly roomName = computed(() => this._state().room?.roomName);
 
+	readonly roomPasscode = computed(() => this._state().room?.passcode);
+
+	readonly roomRequiresPasscode = computed(() => !!this._state().room?.passcode);
+
+	readonly guestCaptchaConfig = computed(() => this._state().guestCaptchaConfig);
+
+	readonly guestCaptchaEnabled = computed(() => {
+		const config = this._state().guestCaptchaConfig;
+		return !!config?.enabled && !!config.siteKey;
+	});
+
+	readonly captchaToken = computed(() => this._state().captchaToken);
+
 	/**
 	 * Computed signal for has recordings.
 	 * Obtained from MeetingContextService
@@ -136,6 +154,10 @@ export class MeetingLobbyService {
 		this._state().participantForm.get('e2eeKey')?.setValue(key);
 	}
 
+	setCaptchaToken(token?: string): void {
+		this._state.update((state) => ({ ...state, captchaToken: token }));
+	}
+
 	/**
 	 * Initializes the lobby state by fetching room data and configuring UI
 	 */
@@ -150,7 +172,8 @@ export class MeetingLobbyService {
 				this.roomService.getRoom(roomId),
 				this.setBackButtonText(),
 				this.checkForRecordings(),
-				this.initializeParticipantName()
+				this.initializeParticipantName(),
+				this.initializeGuestCaptchaConfig()
 			]);
 
 			const roomClosed = room.status === MeetRoomStatus.CLOSED;
@@ -176,6 +199,14 @@ export class MeetingLobbyService {
 					form.get('e2eeKey')?.disable();
 				}
 				form.get('e2eeKey')?.updateValueAndValidity();
+			}
+
+			const form = this._state().participantForm;
+			if (room.passcode) {
+				form
+					.get('passcode')
+					?.setValidators([Validators.required, Validators.minLength(8), Validators.maxLength(8)]);
+				form.get('passcode')?.updateValueAndValidity();
 			}
 		} catch (error) {
 			this.clearLobbyState();
@@ -245,6 +276,14 @@ export class MeetingLobbyService {
 		}
 		this.setParticipantName(sanitized);
 
+		const participantForm = this._state().participantForm;
+		const passcodeControl = participantForm.get('passcode');
+		const roomPasscode = this._state().room?.passcode;
+		if (roomPasscode && passcodeControl) {
+			const normalizedPasscode = (passcodeControl.value || '').trim().toUpperCase();
+			passcodeControl.setValue(normalizedPasscode, { emitEvent: false });
+		}
+
 		// For E2EE rooms, validate passkey
 		const { hasRoomE2EEEnabled, roomId } = this._state();
 		if (hasRoomE2EEEnabled) {
@@ -256,7 +295,10 @@ export class MeetingLobbyService {
 			this.meetingContextService.setE2eeKey(e2eeKey);
 		}
 
-		await this.generateRoomMemberToken();
+		const tokenGenerated = await this.generateRoomMemberToken();
+		if (!tokenGenerated) {
+			return;
+		}
 		await Promise.all([this.addParticipantNameToUrl(), this.roomService.loadRoomConfig(roomId!)]);
 	}
 
@@ -343,24 +385,35 @@ export class MeetingLobbyService {
 	 *
 	 * @returns Promise that resolves when token is generated
 	 */
-	protected async generateRoomMemberToken() {
+	protected async generateRoomMemberToken(): Promise<boolean> {
 		try {
 			const roomId = this._state().roomId;
 			const roomSecret = this.meetingContextService.roomSecret();
+			const captchaToken = this._state().captchaToken;
+			const roomPasscode = this._state().participantForm.get('passcode')?.value as string | undefined;
 			const roomMemberToken = await this.roomMemberService.generateToken(
 				roomId!,
 				{
 					secret: roomSecret!,
 					grantJoinMeetingPermission: true,
-					participantName: this.participantName()
+					participantName: this.participantName(),
+					captchaToken,
+					roomPasscode
 				},
 				this.e2eeKeyValue()
 			);
 			const updatedName = this.roomMemberService.getParticipantName()!;
 			this.setParticipantName(updatedName);
 			this._state.update((state) => ({ ...state, roomMemberToken }));
+			return true;
 		} catch (error: any) {
 			this.log.e('Error generating room member token:', error);
+			const message = (error?.error?.message || error?.message || '').toString();
+			if (error.status === 403 && /passcode/i.test(message)) {
+				this._state().participantForm.get('passcode')?.setErrors({ invalidPasscode: true });
+				return false;
+			}
+
 			switch (error.status) {
 				case 400:
 					// Invalid secret
@@ -391,6 +444,24 @@ export class MeetingLobbyService {
 		});
 	}
 
+	protected async initializeGuestCaptchaConfig(): Promise<void> {
+		try {
+			this.log.d('[captcha] Loading guest captcha config...');
+			const guestCaptchaConfig = await this.globalConfigService.getGuestCaptchaConfig();
+			this.log.d('[captcha] Guest captcha config loaded', guestCaptchaConfig);
+			this._state.update((state) => ({ ...state, guestCaptchaConfig }));
+		} catch (error) {
+			this.log.w('Unable to load guest captcha config. Continuing without captcha.', error);
+			this._state.update((state) => ({
+				...state,
+				guestCaptchaConfig: {
+					enabled: false,
+					provider: 'recaptcha-v2'
+				}
+			}));
+		}
+	}
+
 	protected clearLobbyState() {
 		this._state.set({
 			roomId: undefined,
@@ -399,8 +470,11 @@ export class MeetingLobbyService {
 			showBackButton: true,
 			backButtonText: 'Back',
 			hasRoomE2EEEnabled: false,
+			guestCaptchaConfig: undefined,
+			captchaToken: undefined,
 			participantForm: new FormGroup({
 				name: new FormControl('', [Validators.required]),
+				passcode: new FormControl(''),
 				e2eeKey: new FormControl('')
 			}),
 			roomMemberToken: undefined

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/services/meeting.service.ts
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/meeting/services/meeting.service.ts
@@ -23,10 +23,12 @@ export class MeetingService {
 	 */
 	copyMeetingSpeakerLink(room: MeetRoom): void {
 		const speakerLink = room.speakerUrl;
-		this.clipboard.copy(speakerLink);
-		this.notificationService.showSnackbar('Speaker link copied to clipboard');
+		const textToCopy = room.passcode ? `${speakerLink}\nPasscode: ${room.passcode}` : speakerLink;
+		this.clipboard.copy(textToCopy);
+		this.notificationService.showSnackbar(
+			room.passcode ? 'Speaker link and passcode copied to clipboard' : 'Speaker link copied to clipboard'
+		);
 	}
-
 
 	/**
 	 * Ends a meeting by its room ID.

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/rooms/interceptor-handlers/room-member-error-handler.service.ts
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/rooms/interceptor-handlers/room-member-error-handler.service.ts
@@ -1,7 +1,11 @@
 import { HttpErrorResponse, HttpEvent } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable, catchError, from, switchMap, throwError } from 'rxjs';
-import { HttpErrorContext, HttpErrorHandler, HttpErrorNotifierService } from '../../../shared/services/http-error-notifier.service';
+import {
+	HttpErrorContext,
+	HttpErrorHandler,
+	HttpErrorNotifierService
+} from '../../../shared/services/http-error-notifier.service';
 import { TokenStorageService } from '../../../shared/services/token-storage.service';
 import { MeetingContextService } from '../../meeting/services/meeting-context.service';
 import { RoomMemberService } from '../services/room-member.service';
@@ -75,6 +79,7 @@ export class RoomMemberInterceptorErrorHandlerService implements HttpErrorHandle
 
 		const participantName = this.roomMemberService.getParticipantName();
 		const participantIdentity = this.roomMemberService.getParticipantIdentity();
+		const roomPasscode = this.roomMemberService.getRoomPasscode();
 		const grantJoinMeetingPermission = !!participantIdentity; // Grant join permission if identity is set
 
 		return from(
@@ -82,7 +87,8 @@ export class RoomMemberInterceptorErrorHandlerService implements HttpErrorHandle
 				secret,
 				grantJoinMeetingPermission,
 				participantName,
-				participantIdentity
+				participantIdentity,
+				roomPasscode
 			})
 		).pipe(
 			switchMap(() => {

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/rooms/pages/room-basic-creation/room-basic-creation.component.html
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/rooms/pages/room-basic-creation/room-basic-creation.component.html
@@ -24,6 +24,44 @@
 				}
 			</mat-form-field>
 
+			<mat-form-field appearance="outline" class="form-field">
+				<mat-label>Meeting Passcode</mat-label>
+				<input matInput formControlName="passcode" placeholder="8-character code" maxlength="8" />
+				<button
+					mat-icon-button
+					matSuffix
+					type="button"
+					(click)="onGeneratePasscode()"
+					matTooltip="Generate new passcode"
+				>
+					<mat-icon class="ov-settings-icon">refresh</mat-icon>
+				</button>
+				<mat-hint>Share this passcode with participants to join the room.</mat-hint>
+				@if (roomDetailsForm.get('passcode')?.hasError('required')) {
+					<mat-error>Passcode is required</mat-error>
+				}
+				@if (
+					roomDetailsForm.get('passcode')?.hasError('minlength') ||
+					roomDetailsForm.get('passcode')?.hasError('maxlength') ||
+					roomDetailsForm.get('passcode')?.hasError('pattern')
+				) {
+					<mat-error>Passcode must contain exactly 8 letters or numbers</mat-error>
+				}
+			</mat-form-field>
+
+			<mat-form-field appearance="outline" class="form-field">
+				<mat-label>Max participants</mat-label>
+				<input matInput type="number" formControlName="maxParticipants" min="1" placeholder="e.g. 10" />
+				<mat-icon matSuffix class="ov-settings-icon">groups</mat-icon>
+				<mat-hint>Default is 10 participants for new rooms.</mat-hint>
+				@if (roomDetailsForm.get('maxParticipants')?.hasError('required')) {
+					<mat-error>Max participants is required</mat-error>
+				}
+				@if (roomDetailsForm.get('maxParticipants')?.hasError('min')) {
+					<mat-error>Max participants must be at least 1</mat-error>
+				}
+			</mat-form-field>
+
 			<!-- Action Buttons -->
 			<div class="action-buttons">
 				<button

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/rooms/pages/room-basic-creation/room-basic-creation.component.ts
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/rooms/pages/room-basic-creation/room-basic-creation.component.ts
@@ -10,24 +10,26 @@ import { Subject, takeUntil } from 'rxjs';
 import { RoomWizardStateService } from '../../services';
 
 @Component({
-    selector: 'ov-room-basic-creation',
-    imports: [
-        ReactiveFormsModule,
-        MatButtonModule,
-        MatIconModule,
-        MatInputModule,
-        MatFormFieldModule,
-        MatTooltipModule
-    ],
-    templateUrl: './room-basic-creation.component.html',
-    styleUrl: './room-basic-creation.component.scss'
+	selector: 'ov-room-basic-creation',
+	imports: [
+		ReactiveFormsModule,
+		MatButtonModule,
+		MatIconModule,
+		MatInputModule,
+		MatFormFieldModule,
+		MatTooltipModule
+	],
+	templateUrl: './room-basic-creation.component.html',
+	styleUrl: './room-basic-creation.component.scss'
 })
 export class RoomBasicCreationComponent implements OnDestroy {
-	@Output() createRoom = new EventEmitter<string | undefined>();
+	@Output() createRoom = new EventEmitter<Pick<MeetRoomOptions, 'roomName' | 'passcode' | 'maxParticipants'>>();
 	@Output() openAdvancedMode = new EventEmitter<void>();
 
 	roomDetailsForm = new FormGroup({
-		roomName: new FormControl('Room', [Validators.maxLength(50)])
+		roomName: new FormControl('Room', [Validators.maxLength(50)]),
+		passcode: new FormControl(''),
+		maxParticipants: new FormControl(10, [Validators.required, Validators.min(1)])
 	});
 
 	private destroy$ = new Subject<void>();
@@ -51,8 +53,11 @@ export class RoomBasicCreationComponent implements OnDestroy {
 	}
 
 	private saveFormData(formValue: any) {
+		const normalizedPasscode = formValue.passcode?.toUpperCase();
 		const stepData: Partial<MeetRoomOptions> = {
-			roomName: formValue.roomName
+			roomName: formValue.roomName,
+			passcode: normalizedPasscode,
+			maxParticipants: formValue.maxParticipants
 		};
 		this.wizardService.updateStepData('roomDetails', stepData);
 	}
@@ -60,8 +65,29 @@ export class RoomBasicCreationComponent implements OnDestroy {
 	onCreateRoom() {
 		if (this.roomDetailsForm.valid) {
 			const formValue = this.roomDetailsForm.value;
-			this.createRoom.emit(formValue.roomName || undefined);
+			const normalizedPasscode = formValue.passcode?.toUpperCase();
+			this.createRoom.emit({
+				roomName: formValue.roomName || undefined,
+				passcode: normalizedPasscode || undefined,
+				maxParticipants: formValue.maxParticipants || undefined
+			});
 		}
+	}
+
+	onGeneratePasscode(): void {
+		const generated = this.generatePasscode();
+		this.roomDetailsForm.get('passcode')?.setValue(generated);
+	}
+
+	private generatePasscode(): string {
+		const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+		let result = '';
+
+		for (let i = 0; i < 8; i++) {
+			result += charset[Math.floor(Math.random() * charset.length)];
+		}
+
+		return result;
 	}
 
 	onOpenAdvancedMode() {

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/rooms/pages/room-wizard/room-wizard.component.ts
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/rooms/pages/room-wizard/room-wizard.component.ts
@@ -90,8 +90,8 @@ export class RoomWizardComponent implements OnInit {
 		if (!this.roomId) return;
 
 		try {
-			const { roomName, autoDeletionDate, config } = await this.roomService.getRoom(this.roomId);
-			this.existingRoomData = { roomName, autoDeletionDate, config };
+			const { roomName, passcode, autoDeletionDate, config } = await this.roomService.getRoom(this.roomId);
+			this.existingRoomData = { roomName, passcode, autoDeletionDate, config };
 			if (this.existingRoomData) {
 				this.isBasicCreation.set(false);
 			}
@@ -128,10 +128,14 @@ export class RoomWizardComponent implements OnInit {
 		await this.navigationService.navigateTo('rooms', undefined, true);
 	}
 
-	async createRoomBasic(roomName?: string) {
+	async createRoomBasic({
+		roomName,
+		passcode,
+		maxParticipants
+	}: Pick<MeetRoomOptions, 'roomName' | 'passcode' | 'maxParticipants'>) {
 		try {
 			// Create room with basic config including e2ee: false (default settings)
-			const { moderatorUrl } = await this.roomService.createRoom({ roomName });
+			const { moderatorUrl } = await this.roomService.createRoom({ roomName, passcode, maxParticipants });
 
 			// Extract the path and query parameters from the moderator URL and navigate to it
 			const url = new URL(moderatorUrl);

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/rooms/pages/room-wizard/steps/room-config/room-config.component.html
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/rooms/pages/room-wizard/steps/room-config/room-config.component.html
@@ -11,6 +11,76 @@
 	<!-- Form Section -->
 	<main class="step-content">
 		<form [formGroup]="configForm" class="config-form">
+			<div class="form-field-row">
+				<mat-form-field appearance="outline" class="config-select-field">
+					<mat-label>Media mode</mat-label>
+					<mat-select [value]="mediaMode" (selectionChange)="onMediaModeChange($event.value)">
+						@for (option of mediaModeOptions; track option.value) {
+							<mat-option [value]="option.value">{{ option.label }}</mat-option>
+						}
+					</mat-select>
+				</mat-form-field>
+
+				<mat-form-field appearance="outline" class="config-select-field">
+					<mat-label>Screen sharing access</mat-label>
+					<mat-select [value]="screenShareAccess" (selectionChange)="onScreenShareAccessChange($event.value)">
+						@for (option of screenShareAccessOptions; track option.value) {
+							<mat-option [value]="option.value">{{ option.label }}</mat-option>
+						}
+					</mat-select>
+				</mat-form-field>
+			</div>
+
+			<mat-card class="config-card media-preview-card">
+				<mat-card-content>
+					<div class="card-header">
+						<div class="icon-title-group">
+							<mat-icon class="feature-icon">tune</mat-icon>
+							<div class="title-group">
+								<h4 class="card-title">Media controls preview</h4>
+								<p class="card-description">
+									The controls available during the meeting are derived from the selected media mode.
+								</p>
+							</div>
+						</div>
+					</div>
+
+					<div class="media-preview-list">
+						<div class="media-preview-item">
+							<div class="media-preview-label">
+								<mat-icon class="media-preview-icon">videocam</mat-icon>
+								<span>Video</span>
+							</div>
+							<mat-slide-toggle [checked]="isRoomVideoEnabled" disabled></mat-slide-toggle>
+						</div>
+
+						<div class="media-preview-item">
+							<div class="media-preview-label">
+								<mat-icon class="media-preview-icon">mic</mat-icon>
+								<span>Audio</span>
+							</div>
+							<mat-slide-toggle [checked]="isRoomAudioEnabled" disabled></mat-slide-toggle>
+						</div>
+
+						<div class="media-preview-item">
+							<div class="media-preview-label">
+								<mat-icon class="media-preview-icon">screen_share</mat-icon>
+								<span>Screen share</span>
+							</div>
+							<mat-slide-toggle [checked]="isRoomScreenShareEnabled" disabled></mat-slide-toggle>
+						</div>
+					</div>
+
+					<p class="media-preview-hint">
+						@if (isRoomScreenShareEnabled) {
+							Allowed for: {{ screenShareAccessLabel }}
+						} @else {
+							Screen sharing is disabled in Audio-only mode.
+						}
+					</p>
+				</mat-card-content>
+			</mat-card>
+
 			<!-- Config Cards Grid -->
 			<div class="config-grid">
 				<!-- End-to-End Encryption Card -->

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/rooms/pages/room-wizard/steps/room-config/room-config.component.scss
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/rooms/pages/room-wizard/steps/room-config/room-config.component.scss
@@ -4,7 +4,7 @@
 	@include design-tokens.ov-page-content;
 	@include design-tokens.ov-container;
 
-    justify-content: center;
+	justify-content: center;
 
 	.step-header {
 		display: flex;
@@ -44,6 +44,62 @@
 		.config-form {
 			display: flex;
 			flex-direction: column;
+			gap: var(--ov-meet-spacing-md);
+
+			.form-field-row {
+				display: grid;
+				grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+				gap: var(--ov-meet-spacing-sm);
+
+				.config-select-field {
+					width: 100%;
+				}
+			}
+		}
+	}
+
+	.media-preview-card {
+		mat-card-content {
+			padding: 0;
+		}
+
+		.media-preview-list {
+			display: flex;
+			flex-direction: column;
+			gap: var(--ov-meet-spacing-sm);
+			margin-top: var(--ov-meet-spacing-sm);
+		}
+
+		.media-preview-item {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			padding: var(--ov-meet-spacing-xs) 0;
+			border-bottom: 1px solid var(--ov-meet-border-secondary);
+
+			&:last-child {
+				border-bottom: 0;
+			}
+		}
+
+		.media-preview-label {
+			display: inline-flex;
+			align-items: center;
+			gap: var(--ov-meet-spacing-xs);
+			color: var(--ov-meet-text-primary);
+			font-size: var(--ov-meet-font-size-sm);
+			font-weight: var(--ov-meet-font-weight-medium);
+		}
+
+		.media-preview-icon {
+			@include design-tokens.ov-icon(md);
+			color: var(--ov-meet-icon-primary);
+		}
+
+		.media-preview-hint {
+			margin: var(--ov-meet-spacing-sm) 0 0;
+			font-size: var(--ov-meet-font-size-sm);
+			color: var(--ov-meet-text-secondary);
 		}
 	}
 

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/rooms/pages/room-wizard/steps/room-config/room-config.component.ts
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/rooms/pages/room-wizard/steps/room-config/room-config.component.ts
@@ -1,19 +1,39 @@
 import { Component, OnDestroy } from '@angular/core';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
+import { MatSelectModule } from '@angular/material/select';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MeetRoomMediaMode, MeetScreenShareAccess } from '@openvidu-meet/typings';
 import { Subject, takeUntil } from 'rxjs';
 import { RoomWizardStateService } from '../../../../services';
 
 @Component({
 	selector: 'ov-room-config',
-	imports: [ReactiveFormsModule, MatCardModule, MatIconModule, MatSlideToggleModule],
+	imports: [
+		ReactiveFormsModule,
+		MatCardModule,
+		MatIconModule,
+		MatSlideToggleModule,
+		MatFormFieldModule,
+		MatSelectModule
+	],
 	templateUrl: './room-config.component.html',
 	styleUrl: './room-config.component.scss'
 })
 export class RoomConfigComponent implements OnDestroy {
 	configForm: FormGroup;
+	readonly mediaModeOptions = [
+		{ value: MeetRoomMediaMode.STANDARD, label: 'Standard (audio + video)' },
+		{ value: MeetRoomMediaMode.VIDEO_DISABLED, label: 'Video disabled (audio only camera off)' },
+		{ value: MeetRoomMediaMode.AUDIO_ONLY, label: 'Audio-only room (camera and screen share off)' }
+	];
+	readonly screenShareAccessOptions = [
+		{ value: MeetScreenShareAccess.ADMIN, label: 'Admin only' },
+		{ value: MeetScreenShareAccess.ADMIN_MODERATOR, label: 'Admin and moderators' },
+		{ value: MeetScreenShareAccess.ADMIN_MODERATOR_SPEAKER, label: 'All users' }
+	];
 
 	private destroy$ = new Subject<void>();
 	// Store the previous recording state before E2EE disables it
@@ -44,6 +64,12 @@ export class RoomConfigComponent implements OnDestroy {
 				},
 				e2ee: {
 					enabled: formValue.e2eeEnabled ?? false
+				},
+				media: {
+					mode: formValue.mediaMode ?? MeetRoomMediaMode.STANDARD
+				},
+				screenShare: {
+					allowAccessTo: formValue.screenShareAccess ?? MeetScreenShareAccess.ADMIN_MODERATOR_SPEAKER
 				},
 				captions: {
 					enabled: formValue.captionsEnabled ?? false
@@ -110,6 +136,14 @@ export class RoomConfigComponent implements OnDestroy {
 		this.configForm.patchValue({ captionsEnabled: isEnabled });
 	}
 
+	onMediaModeChange(mode: MeetRoomMediaMode): void {
+		this.configForm.patchValue({ mediaMode: mode });
+	}
+
+	onScreenShareAccessChange(access: MeetScreenShareAccess): void {
+		this.configForm.patchValue({ screenShareAccess: access });
+	}
+
 	get chatEnabled(): boolean {
 		return this.configForm.value.chatEnabled || false;
 	}
@@ -124,5 +158,37 @@ export class RoomConfigComponent implements OnDestroy {
 
 	get captionsEnabled(): boolean {
 		return this.configForm.value.captionsEnabled ?? false;
+	}
+
+	get mediaMode(): MeetRoomMediaMode {
+		return this.configForm.value.mediaMode ?? MeetRoomMediaMode.STANDARD;
+	}
+
+	get screenShareAccess(): MeetScreenShareAccess {
+		return this.configForm.value.screenShareAccess ?? MeetScreenShareAccess.ADMIN_MODERATOR_SPEAKER;
+	}
+
+	get isRoomVideoEnabled(): boolean {
+		return this.mediaMode === MeetRoomMediaMode.STANDARD;
+	}
+
+	get isRoomAudioEnabled(): boolean {
+		return true;
+	}
+
+	get isRoomScreenShareEnabled(): boolean {
+		return this.mediaMode !== MeetRoomMediaMode.AUDIO_ONLY;
+	}
+
+	get screenShareAccessLabel(): string {
+		switch (this.screenShareAccess) {
+			case MeetScreenShareAccess.ADMIN:
+				return 'Admin only';
+			case MeetScreenShareAccess.ADMIN_MODERATOR:
+				return 'Admin and moderators';
+			case MeetScreenShareAccess.ADMIN_MODERATOR_SPEAKER:
+			default:
+				return 'All users';
+		}
 	}
 }

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/rooms/pages/room-wizard/steps/room-details/room-details.component.html
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/rooms/pages/room-wizard/steps/room-details/room-details.component.html
@@ -22,6 +22,45 @@
 				}
 			</mat-form-field>
 
+			<mat-form-field appearance="outline" class="form-field">
+				<mat-label>Meeting Passcode</mat-label>
+				<input matInput formControlName="passcode" placeholder="8-character code" maxlength="8" />
+				<button
+					mat-icon-button
+					matSuffix
+					type="button"
+					[disabled]="roomDetailsForm.get('passcode')?.disabled"
+					(click)="onGeneratePasscode()"
+					matTooltip="Generate new passcode"
+				>
+					<mat-icon class="ov-settings-icon">refresh</mat-icon>
+				</button>
+				<mat-hint>Participants must provide this passcode before joining.</mat-hint>
+				@if (roomDetailsForm.get('passcode')?.hasError('required')) {
+					<mat-error>Passcode is required</mat-error>
+				}
+				@if (
+					roomDetailsForm.get('passcode')?.hasError('minlength') ||
+					roomDetailsForm.get('passcode')?.hasError('maxlength') ||
+					roomDetailsForm.get('passcode')?.hasError('pattern')
+				) {
+					<mat-error>Passcode must contain exactly 8 letters or numbers</mat-error>
+				}
+			</mat-form-field>
+
+			<mat-form-field appearance="outline" class="form-field">
+				<mat-label>Max participants</mat-label>
+				<input matInput type="number" formControlName="maxParticipants" min="1" placeholder="e.g. 10" />
+				<mat-icon matSuffix class="ov-settings-icon">groups</mat-icon>
+				<mat-hint>Maximum number of participants allowed to join this room.</mat-hint>
+				@if (roomDetailsForm.get('maxParticipants')?.hasError('required')) {
+					<mat-error>Max participants is required</mat-error>
+				}
+				@if (roomDetailsForm.get('maxParticipants')?.hasError('min')) {
+					<mat-error>Max participants must be at least 1</mat-error>
+				}
+			</mat-form-field>
+
 			<!-- Deletion Date Field -->
 			<mat-form-field appearance="outline" class="form-field">
 				<mat-label>Auto-deletion Date</mat-label>

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/rooms/pages/room-wizard/steps/room-details/room-details.component.ts
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/rooms/pages/room-wizard/steps/room-details/room-details.component.ts
@@ -18,20 +18,20 @@ import { Subject, takeUntil } from 'rxjs';
 import { RoomWizardStateService } from '../../../../services';
 
 @Component({
-    selector: 'ov-room-details',
-    imports: [
-        ReactiveFormsModule,
-        MatButtonModule,
-        MatIconModule,
-        MatInputModule,
-        MatFormFieldModule,
-        MatDatepickerModule,
-        MatNativeDateModule,
-        MatSelectModule,
-        MatTooltipModule
-    ],
-    templateUrl: './room-details.component.html',
-    styleUrl: './room-details.component.scss'
+	selector: 'ov-room-details',
+	imports: [
+		ReactiveFormsModule,
+		MatButtonModule,
+		MatIconModule,
+		MatInputModule,
+		MatFormFieldModule,
+		MatDatepickerModule,
+		MatNativeDateModule,
+		MatSelectModule,
+		MatTooltipModule
+	],
+	templateUrl: './room-details.component.html',
+	styleUrl: './room-details.component.scss'
 })
 export class RoomWizardRoomDetailsComponent implements OnDestroy {
 	roomDetailsForm: FormGroup;
@@ -85,6 +85,7 @@ export class RoomWizardRoomDetailsComponent implements OnDestroy {
 	private saveFormData(formValue: any) {
 		let autoDeletionDateTime: number | undefined = undefined;
 		let autoDeletionPolicy: MeetRoomAutoDeletionPolicy | undefined = undefined;
+		const normalizedPasscode = formValue.passcode?.toUpperCase();
 
 		// If date is selected
 		if (formValue.autoDeletionDate) {
@@ -105,6 +106,8 @@ export class RoomWizardRoomDetailsComponent implements OnDestroy {
 
 		const stepData: Partial<MeetRoomOptions> = {
 			roomName: formValue.roomName,
+			passcode: normalizedPasscode,
+			maxParticipants: formValue.maxParticipants,
 			autoDeletionDate: autoDeletionDateTime,
 			autoDeletionPolicy
 		};
@@ -165,5 +168,21 @@ export class RoomWizardRoomDetailsComponent implements OnDestroy {
 		const selectedValue = this.roomDetailsForm.get('autoDeletionPolicyWithRecordings')?.value;
 		const option = this.recordingPolicyOptions.find((opt) => opt.value === selectedValue);
 		return option?.description || '';
+	}
+
+	onGeneratePasscode(): void {
+		const generated = this.generatePasscode();
+		this.roomDetailsForm.get('passcode')?.setValue(generated);
+	}
+
+	private generatePasscode(): string {
+		const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+		let result = '';
+
+		for (let i = 0; i < 8; i++) {
+			result += charset[Math.floor(Math.random() * charset.length)];
+		}
+
+		return result;
 	}
 }

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/rooms/pages/rooms/rooms.component.ts
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/rooms/pages/rooms/rooms.component.ts
@@ -219,13 +219,19 @@ export class RoomsComponent implements OnInit {
 	}
 
 	private copyModeratorLink(room: MeetRoom) {
-		this.clipboard.copy(room.moderatorUrl);
-		this.notificationService.showSnackbar('Moderator link copied to clipboard');
+		const text = room.passcode ? `${room.moderatorUrl}\nPasscode: ${room.passcode}` : room.moderatorUrl;
+		this.clipboard.copy(text);
+		this.notificationService.showSnackbar(
+			room.passcode ? 'Moderator link and passcode copied to clipboard' : 'Moderator link copied to clipboard'
+		);
 	}
 
 	private copySpeakerLink(room: MeetRoom) {
-		this.clipboard.copy(room.speakerUrl);
-		this.notificationService.showSnackbar('Speaker link copied to clipboard');
+		const text = room.passcode ? `${room.speakerUrl}\nPasscode: ${room.passcode}` : room.speakerUrl;
+		this.clipboard.copy(text);
+		this.notificationService.showSnackbar(
+			room.passcode ? 'Speaker link and passcode copied to clipboard' : 'Speaker link copied to clipboard'
+		);
 	}
 
 	private async viewRecordings(room: MeetRoom) {

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/rooms/services/room-member.service.ts
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/rooms/services/room-member.service.ts
@@ -19,6 +19,7 @@ export class RoomMemberService {
 
 	protected participantName?: string;
 	protected participantIdentity?: string;
+	protected roomPasscode?: string;
 	protected role: MeetRoomMemberRole = MeetRoomMemberRole.SPEAKER;
 	protected permissions?: MeetRoomMemberPermissions;
 
@@ -47,6 +48,10 @@ export class RoomMemberService {
 		return this.participantIdentity;
 	}
 
+	getRoomPasscode(): string | undefined {
+		return this.roomPasscode;
+	}
+
 	clearParticipantIdentity(): void {
 		this.participantIdentity = undefined;
 	}
@@ -58,6 +63,10 @@ export class RoomMemberService {
 	 * @return A promise that resolves to the room member token
 	 */
 	async generateToken(roomId: string, tokenOptions: MeetRoomMemberTokenOptions, e2eeKey?: string): Promise<string> {
+		if (tokenOptions.roomPasscode) {
+			this.roomPasscode = tokenOptions.roomPasscode;
+		}
+
 		if (tokenOptions.participantName && e2eeKey) {
 			// Assign E2EE key and encrypt participant name
 			await this.e2eeService.setE2EEKey(e2eeKey);

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/rooms/services/wizard-state.service.ts
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/domains/rooms/services/wizard-state.service.ts
@@ -6,7 +6,9 @@ import {
 	MeetRoomConfig,
 	MeetRoomDeletionPolicyWithMeeting,
 	MeetRoomDeletionPolicyWithRecordings,
-	MeetRoomOptions
+	MeetRoomMediaMode,
+	MeetRoomOptions,
+	MeetScreenShareAccess
 } from '@openvidu-meet/typings';
 import { WizardNavigationConfig, WizardStep } from '../models';
 
@@ -20,7 +22,9 @@ const DEFAULT_CONFIG: MeetRoomConfig = {
 	chat: { enabled: true },
 	virtualBackground: { enabled: true },
 	e2ee: { enabled: false },
-	captions: { enabled: true }
+	captions: { enabled: true },
+	media: { mode: MeetRoomMediaMode.STANDARD },
+	screenShare: { allowAccessTo: MeetScreenShareAccess.ADMIN_MODERATOR_SPEAKER }
 };
 
 /**
@@ -61,9 +65,14 @@ export class RoomWizardStateService {
 	 * @param existingData - Existing room options to prefill the wizard
 	 */
 	initializeWizard(editMode: boolean = false, existingData?: MeetRoomOptions): void {
+		const initialPasscode = existingData?.passcode || this.generatePasscode();
+		const initialMaxParticipants = existingData?.maxParticipants ?? 10;
+
 		// Initialize room options with defaults merged with existing data
 		const initialRoomOptions: MeetRoomOptions = {
 			...existingData,
+			passcode: initialPasscode,
+			maxParticipants: initialMaxParticipants,
 			config: {
 				...DEFAULT_CONFIG,
 				...(existingData?.config || {})
@@ -85,6 +94,21 @@ export class RoomWizardStateService {
 						roomName: [
 							{ value: initialRoomOptions.roomName || 'Room', disabled: editMode },
 							editMode ? [] : [Validators.maxLength(50)]
+						],
+						passcode: [
+							{ value: initialPasscode, disabled: editMode },
+							editMode
+								? []
+								: [
+										Validators.required,
+										Validators.minLength(8),
+										Validators.maxLength(8),
+										Validators.pattern(/^[a-zA-Z0-9]{8}$/)
+									]
+						],
+						maxParticipants: [
+							{ value: initialMaxParticipants, disabled: editMode },
+							editMode ? [] : [Validators.required, Validators.min(1)]
 						],
 						autoDeletionDate: [
 							{
@@ -194,7 +218,9 @@ export class RoomWizardStateService {
 					chatEnabled: initialRoomOptions.config!.chat!.enabled,
 					virtualBackgroundEnabled: initialRoomOptions.config!.virtualBackground!.enabled,
 					e2eeEnabled: initialRoomOptions.config!.e2ee!.enabled,
-					captionsEnabled: initialRoomOptions.config!.captions!.enabled
+					captionsEnabled: initialRoomOptions.config!.captions!.enabled,
+					mediaMode: initialRoomOptions.config!.media!.mode,
+					screenShareAccess: initialRoomOptions.config!.screenShare!.allowAccessTo
 				})
 			}
 		];
@@ -226,6 +252,12 @@ export class RoomWizardStateService {
 				// Only update fields that are explicitly provided
 				if ('roomName' in stepData) {
 					updatedOptions.roomName = stepData.roomName;
+				}
+				if ('passcode' in stepData) {
+					updatedOptions.passcode = stepData.passcode;
+				}
+				if ('maxParticipants' in stepData) {
+					updatedOptions.maxParticipants = stepData.maxParticipants;
 				}
 				if ('autoDeletionDate' in stepData) {
 					updatedOptions.autoDeletionDate = stepData.autoDeletionDate;
@@ -269,6 +301,14 @@ export class RoomWizardStateService {
 							...currentOptions.config?.e2ee,
 							...stepData.config?.e2ee
 						},
+						media: {
+							...currentOptions.config?.media,
+							...stepData.config?.media
+						},
+						screenShare: {
+							...currentOptions.config?.screenShare,
+							...stepData.config?.screenShare
+						},
 						captions: {
 							...currentOptions.config?.captions,
 							...stepData.config?.captions
@@ -290,6 +330,17 @@ export class RoomWizardStateService {
 
 		this._roomOptions.set(updatedOptions);
 		this.updateStepsVisibility();
+	}
+
+	private generatePasscode(): string {
+		const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+		let result = '';
+
+		for (let i = 0; i < 8; i++) {
+			result += charset[Math.floor(Math.random() * charset.length)];
+		}
+
+		return result;
 	}
 
 	/**

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/shared/services/feature-configuration.service.ts
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/shared/services/feature-configuration.service.ts
@@ -48,6 +48,29 @@ const DEFAULT_FEATURES: ApplicationFeatures = {
 export class FeatureConfigurationService {
 	protected log;
 
+	private normalizeTrackSource(source: unknown): TrackSource | undefined {
+		if (typeof source === 'number') {
+			return source as TrackSource;
+		}
+
+		if (typeof source !== 'string') {
+			return undefined;
+		}
+
+		switch (source.toUpperCase()) {
+			case 'CAMERA':
+				return TrackSource.CAMERA;
+			case 'MICROPHONE':
+				return TrackSource.MICROPHONE;
+			case 'SCREEN_SHARE':
+				return TrackSource.SCREEN_SHARE;
+			case 'SCREEN_SHARE_AUDIO':
+				return TrackSource.SCREEN_SHARE_AUDIO;
+			default:
+				return undefined;
+		}
+	}
+
 	// Signals to handle reactive
 	protected roomConfig = signal<MeetRoomConfig | undefined>(undefined);
 	protected roomMemberRole = signal<MeetRoomMemberRole | undefined>(undefined);
@@ -147,11 +170,21 @@ export class FeatureConfigurationService {
 			// Media features
 			const canPublish = permissions.livekit.canPublish;
 			const canPublishSources = permissions.livekit.canPublishSources ?? [];
-			features.videoEnabled = canPublish || canPublishSources.includes(TrackSource.CAMERA);
-			features.audioEnabled = canPublish || canPublishSources.includes(TrackSource.MICROPHONE);
+			const normalizedPublishSources = canPublishSources
+				.map((source) => this.normalizeTrackSource(source))
+				.filter((source): source is TrackSource => source !== undefined);
+			const hasSourceRestrictions = normalizedPublishSources.length > 0;
+			features.videoEnabled = hasSourceRestrictions
+				? normalizedPublishSources.includes(TrackSource.CAMERA)
+				: !!canPublish;
+			features.audioEnabled = hasSourceRestrictions
+				? normalizedPublishSources.includes(TrackSource.MICROPHONE)
+				: !!canPublish;
 			features.showCamera = features.videoEnabled;
 			features.showMicrophone = features.audioEnabled;
-			features.showScreenShare = canPublish || canPublishSources.includes(TrackSource.SCREEN_SHARE);
+			features.showScreenShare = hasSourceRestrictions
+				? normalizedPublishSources.includes(TrackSource.SCREEN_SHARE)
+				: !!canPublish;
 		}
 
 		// Apply role-based configurations

--- a/meet-ce/frontend/projects/shared-meet-components/src/lib/shared/services/global-config.service.ts
+++ b/meet-ce/frontend/projects/shared-meet-components/src/lib/shared/services/global-config.service.ts
@@ -1,5 +1,11 @@
 import { inject, Injectable } from '@angular/core';
-import { AuthMode, MeetAppearanceConfig, SecurityConfig, WebhookConfig } from '@openvidu-meet/typings';
+import {
+	AuthMode,
+	GuestCaptchaConfig,
+	MeetAppearanceConfig,
+	SecurityConfig,
+	WebhookConfig
+} from '@openvidu-meet/typings';
 import { ILogger, LoggerService } from 'openvidu-components-angular';
 import { FeatureConfigurationService } from './feature-configuration.service';
 import { HttpService } from './http.service';
@@ -10,6 +16,7 @@ import { HttpService } from './http.service';
 export class GlobalConfigService {
 	protected readonly GLOBAL_CONFIG_API = `${HttpService.INTERNAL_API_PATH_PREFIX}/config`;
 	protected securityConfig?: SecurityConfig;
+	protected guestCaptchaConfig?: GuestCaptchaConfig;
 	protected loggerService: LoggerService = inject(LoggerService);
 	protected httpService: HttpService = inject(HttpService);
 	protected featureConfService: FeatureConfigurationService = inject(FeatureConfigurationService);
@@ -90,5 +97,15 @@ export class GlobalConfigService {
 			this.log.e('Error loading captions config:', error);
 			throw error;
 		}
+	}
+
+	async getGuestCaptchaConfig(forceRefresh = false): Promise<GuestCaptchaConfig> {
+		if (this.guestCaptchaConfig && !forceRefresh) {
+			return this.guestCaptchaConfig;
+		}
+
+		const path = `${this.GLOBAL_CONFIG_API}/captcha/guest`;
+		this.guestCaptchaConfig = await this.httpService.getRequest<GuestCaptchaConfig>(path);
+		return this.guestCaptchaConfig;
 	}
 }

--- a/meet-ce/typings/src/room-config.ts
+++ b/meet-ce/typings/src/room-config.ts
@@ -1,68 +1,94 @@
-import { MeetRecordingEncodingOptions, MeetRecordingEncodingPreset, MeetRecordingLayout } from './recording.model';
+import {
+  MeetRecordingEncodingOptions,
+  MeetRecordingEncodingPreset,
+  MeetRecordingLayout,
+} from "./recording.model";
 
 /**
  * Interface representing the config for a room.
  */
 export interface MeetRoomConfig {
-	chat: MeetChatConfig;
-	recording: MeetRecordingConfig;
-	virtualBackground: MeetVirtualBackgroundConfig;
-	e2ee: MeetE2EEConfig;
-	captions: MeetRoomCaptionsConfig;
-	// appearance: MeetAppearanceConfig;
+  chat: MeetChatConfig;
+  recording: MeetRecordingConfig;
+  virtualBackground: MeetVirtualBackgroundConfig;
+  e2ee: MeetE2EEConfig;
+  captions: MeetRoomCaptionsConfig;
+  media: MeetRoomMediaConfig;
+  screenShare: MeetRoomScreenShareConfig;
+  // appearance: MeetAppearanceConfig;
 }
 
 /**
  * Interface representing the config for recordings in a room.
  */
 export interface MeetRecordingConfig {
-	enabled: boolean;
-	layout?: MeetRecordingLayout;
-	/**
-	 * Encoding configuration: use a preset string for common scenarios,
-	 * or provide detailed options for fine-grained control.
-	 */
-	encoding?: MeetRecordingEncodingPreset | MeetRecordingEncodingOptions;
-	allowAccessTo?: MeetRecordingAccess;
+  enabled: boolean;
+  layout?: MeetRecordingLayout;
+  /**
+   * Encoding configuration: use a preset string for common scenarios,
+   * or provide detailed options for fine-grained control.
+   */
+  encoding?: MeetRecordingEncodingPreset | MeetRecordingEncodingOptions;
+  allowAccessTo?: MeetRecordingAccess;
 }
 
 export enum MeetRecordingAccess {
-	ADMIN = 'admin', // Only admins can access the recording
-	ADMIN_MODERATOR = 'admin_moderator', // Admins and moderators can access
-	ADMIN_MODERATOR_SPEAKER = 'admin_moderator_speaker', // Admins, moderators and speakers can access
+  ADMIN = "admin", // Only admins can access the recording
+  ADMIN_MODERATOR = "admin_moderator", // Admins and moderators can access
+  ADMIN_MODERATOR_SPEAKER = "admin_moderator_speaker", // Admins, moderators and speakers can access
 }
 
 export interface MeetChatConfig {
-	enabled: boolean;
+  enabled: boolean;
 }
 
 export interface MeetVirtualBackgroundConfig {
-	enabled: boolean;
+  enabled: boolean;
 }
 
 export interface MeetE2EEConfig {
-	enabled: boolean;
+  enabled: boolean;
 }
 export interface MeetRoomCaptionsConfig {
-	enabled: boolean;
+  enabled: boolean;
+}
+
+export interface MeetRoomMediaConfig {
+  mode: MeetRoomMediaMode;
+}
+
+export enum MeetRoomMediaMode {
+  STANDARD = "standard",
+  VIDEO_DISABLED = "video_disabled",
+  AUDIO_ONLY = "audio_only",
+}
+
+export interface MeetRoomScreenShareConfig {
+  allowAccessTo: MeetScreenShareAccess;
+}
+
+export enum MeetScreenShareAccess {
+  ADMIN = "admin",
+  ADMIN_MODERATOR = "admin_moderator",
+  ADMIN_MODERATOR_SPEAKER = "admin_moderator_speaker",
 }
 
 export interface MeetAppearanceConfig {
-	themes: MeetRoomTheme[];
+  themes: MeetRoomTheme[];
 }
 
 export interface MeetRoomTheme {
-	name: string;
-	enabled: boolean;
-	baseTheme: MeetRoomThemeMode;
-	backgroundColor?: string;
-	primaryColor?: string;
-	secondaryColor?: string;
-	accentColor?: string;
-	surfaceColor?: string;
+  name: string;
+  enabled: boolean;
+  baseTheme: MeetRoomThemeMode;
+  backgroundColor?: string;
+  primaryColor?: string;
+  secondaryColor?: string;
+  accentColor?: string;
+  surfaceColor?: string;
 }
 
 export enum MeetRoomThemeMode {
-	LIGHT = 'light',
-	DARK = 'dark',
+  LIGHT = "light",
+  DARK = "dark",
 }

--- a/meet-ce/typings/src/room-member.ts
+++ b/meet-ce/typings/src/room-member.ts
@@ -1,46 +1,63 @@
-import { LiveKitPermissions } from './permissions/livekit-permissions.js';
-import { MeetPermissions } from './permissions/meet-permissions.js';
+import { LiveKitPermissions } from "./permissions/livekit-permissions.js";
+import { MeetPermissions } from "./permissions/meet-permissions.js";
 
 /**
  * Options for generating a room member token.
  * A room member token provides access to room resources (recordings, meetings, etc.)
  */
 export interface MeetRoomMemberTokenOptions {
-    /**
-     * A secret key for room access. Determines the member's role.
-     */
-    secret: string;
-    /**
-     * Whether to include meeting join permissions in the token.
-     * If true, participantName must be provided.
-     */
-    grantJoinMeetingPermission?: boolean;
-    /**
-     * The name of the participant when joining the meeting.
-     * Required if grantJoinMeetingPermission is true and this is a new token (not a refresh).
-     */
-    participantName?: string;
-    /**
-     * The identity of the participant in the meeting.
-     * Required when refreshing an existing token with meeting permissions.
-     */
-    participantIdentity?: string;
+  /**
+   * A secret key for room access. Determines the member's role.
+   */
+  secret: string;
+  /**
+   * Whether to include meeting join permissions in the token.
+   * If true, participantName must be provided.
+   */
+  grantJoinMeetingPermission?: boolean;
+  /**
+   * The name of the participant when joining the meeting.
+   * Required if grantJoinMeetingPermission is true and this is a new token (not a refresh).
+   */
+  participantName?: string;
+  /**
+   * The identity of the participant in the meeting.
+   * Required when refreshing an existing token with meeting permissions.
+   */
+  participantIdentity?: string;
+  /**
+   * Optional captcha token used to validate human access when joining a meeting.
+   */
+  captchaToken?: string;
+  /**
+   * Optional room passcode required to join protected rooms.
+   */
+  roomPasscode?: string;
+}
+
+/**
+ * Public configuration for guest captcha challenges.
+ */
+export interface GuestCaptchaConfig {
+  enabled: boolean;
+  provider: "recaptcha-v2";
+  siteKey?: string;
 }
 
 /**
  * Represents the permissions for an individual participant.
  */
 export interface MeetRoomMemberPermissions {
-    livekit: LiveKitPermissions;
-    meet: MeetPermissions;
+  livekit: LiveKitPermissions;
+  meet: MeetPermissions;
 }
 
 /**
  * Represents the role of a participant in a room.
  */
 export enum MeetRoomMemberRole {
-    MODERATOR = 'moderator',
-    SPEAKER = 'speaker'
+  MODERATOR = "moderator",
+  SPEAKER = "speaker",
 }
 
 /**
@@ -48,7 +65,7 @@ export enum MeetRoomMemberRole {
  * Contains information about roles and permissions for accessing room resources.
  */
 export interface MeetRoomMemberTokenMetadata {
-    livekitUrl: string;
-    role: MeetRoomMemberRole;
-    permissions: MeetPermissions;
+  livekitUrl: string;
+  role: MeetRoomMemberRole;
+  permissions: MeetPermissions;
 }

--- a/meet-ce/typings/src/room.ts
+++ b/meet-ce/typings/src/room.ts
@@ -1,88 +1,92 @@
-import { MeetRoomConfig } from './room-config.js';
-import { MeetRoomMemberPermissions, MeetRoomMemberRole } from './room-member.js';
-import { SortAndPagination } from './sort-pagination.js';
+import { MeetRoomConfig } from "./room-config.js";
+import {
+  MeetRoomMemberPermissions,
+  MeetRoomMemberRole,
+} from "./room-member.js";
+import { SortAndPagination } from "./sort-pagination.js";
 
 /**
  * Options for creating a room.
  */
 export interface MeetRoomOptions {
-    roomName?: string;
-    autoDeletionDate?: number;
-    autoDeletionPolicy?: MeetRoomAutoDeletionPolicy;
-    config?: Partial<MeetRoomConfig>;
-    // maxParticipants?: number | null;
+  roomName?: string;
+  passcode?: string;
+  maxParticipants?: number;
+  autoDeletionDate?: number;
+  autoDeletionPolicy?: MeetRoomAutoDeletionPolicy;
+  config?: Partial<MeetRoomConfig>;
 }
 
 /**
  * Representation of a room
  */
 export interface MeetRoom extends MeetRoomOptions {
-    roomId: string;
-    roomName: string;
-    creationDate: number;
-    config: MeetRoomConfig;
-    moderatorUrl: string;
-    speakerUrl: string;
-    status: MeetRoomStatus;
-    meetingEndAction: MeetingEndAction; // Action to take on the room when the meeting ends
+  roomId: string;
+  roomName: string;
+  creationDate: number;
+  config: MeetRoomConfig;
+  moderatorUrl: string;
+  speakerUrl: string;
+  status: MeetRoomStatus;
+  meetingEndAction: MeetingEndAction; // Action to take on the room when the meeting ends
 }
 
 export enum MeetRoomStatus {
-    OPEN = 'open', // Room is open and available to host a meeting
-    ACTIVE_MEETING = 'active_meeting', // There is an ongoing meeting in the room
-    CLOSED = 'closed' // Room is closed to hosting new meetings
+  OPEN = "open", // Room is open and available to host a meeting
+  ACTIVE_MEETING = "active_meeting", // There is an ongoing meeting in the room
+  CLOSED = "closed", // Room is closed to hosting new meetings
 }
 
 export enum MeetingEndAction {
-    NONE = 'none', // No action is taken when the meeting ends
-    CLOSE = 'close', // The room will be closed when the meeting ends
-    DELETE = 'delete' // The room (and its recordings if any) will be deleted when the meeting ends
+  NONE = "none", // No action is taken when the meeting ends
+  CLOSE = "close", // The room will be closed when the meeting ends
+  DELETE = "delete", // The room (and its recordings if any) will be deleted when the meeting ends
 }
 
 export interface MeetRoomAutoDeletionPolicy {
-    withMeeting: MeetRoomDeletionPolicyWithMeeting;
-    withRecordings: MeetRoomDeletionPolicyWithRecordings;
+  withMeeting: MeetRoomDeletionPolicyWithMeeting;
+  withRecordings: MeetRoomDeletionPolicyWithRecordings;
 }
 
 export enum MeetRoomDeletionPolicyWithMeeting {
-    FORCE = 'force', // Force deletion even if there is an active meeting
-    WHEN_MEETING_ENDS = 'when_meeting_ends', // Delete the room when the meeting ends
-    FAIL = 'fail' // Fail the deletion if there is an active meeting
+  FORCE = "force", // Force deletion even if there is an active meeting
+  WHEN_MEETING_ENDS = "when_meeting_ends", // Delete the room when the meeting ends
+  FAIL = "fail", // Fail the deletion if there is an active meeting
 }
 
 export enum MeetRoomDeletionPolicyWithRecordings {
-    FORCE = 'force', // Force deletion even if there are ongoing or previous recordings
-    CLOSE = 'close', // Close the room and keep recordings
-    FAIL = 'fail' // Fail the deletion if there are ongoing or previous recordings
+  FORCE = "force", // Force deletion even if there are ongoing or previous recordings
+  CLOSE = "close", // Close the room and keep recordings
+  FAIL = "fail", // Fail the deletion if there are ongoing or previous recordings
 }
 
 export interface MeetRoomMemberRoleAndPermissions {
-    role: MeetRoomMemberRole;
-    permissions: MeetRoomMemberPermissions;
+  role: MeetRoomMemberRole;
+  permissions: MeetRoomMemberPermissions;
 }
 
 export interface MeetRoomFilters extends SortAndPagination {
-    roomName?: string;
-    status?: MeetRoomStatus;
-    fields?: string;
+  roomName?: string;
+  status?: MeetRoomStatus;
+  fields?: string;
 }
 
 export enum MeetRoomDeletionSuccessCode {
-    ROOM_DELETED = 'room_deleted',
-    ROOM_WITH_ACTIVE_MEETING_DELETED = 'room_with_active_meeting_deleted',
-    ROOM_WITH_ACTIVE_MEETING_SCHEDULED_TO_BE_DELETED = 'room_with_active_meeting_scheduled_to_be_deleted',
-    ROOM_AND_RECORDINGS_DELETED = 'room_and_recordings_deleted',
-    ROOM_CLOSED = 'room_closed',
-    ROOM_WITH_ACTIVE_MEETING_AND_RECORDINGS_DELETED = 'room_with_active_meeting_and_recordings_deleted',
-    ROOM_WITH_ACTIVE_MEETING_CLOSED = 'room_with_active_meeting_closed',
-    ROOM_WITH_ACTIVE_MEETING_AND_RECORDINGS_SCHEDULED_TO_BE_DELETED = 'room_with_active_meeting_and_recordings_scheduled_to_be_deleted',
-    ROOM_WITH_ACTIVE_MEETING_SCHEDULED_TO_BE_CLOSED = 'room_with_active_meeting_scheduled_to_be_closed'
+  ROOM_DELETED = "room_deleted",
+  ROOM_WITH_ACTIVE_MEETING_DELETED = "room_with_active_meeting_deleted",
+  ROOM_WITH_ACTIVE_MEETING_SCHEDULED_TO_BE_DELETED = "room_with_active_meeting_scheduled_to_be_deleted",
+  ROOM_AND_RECORDINGS_DELETED = "room_and_recordings_deleted",
+  ROOM_CLOSED = "room_closed",
+  ROOM_WITH_ACTIVE_MEETING_AND_RECORDINGS_DELETED = "room_with_active_meeting_and_recordings_deleted",
+  ROOM_WITH_ACTIVE_MEETING_CLOSED = "room_with_active_meeting_closed",
+  ROOM_WITH_ACTIVE_MEETING_AND_RECORDINGS_SCHEDULED_TO_BE_DELETED = "room_with_active_meeting_and_recordings_scheduled_to_be_deleted",
+  ROOM_WITH_ACTIVE_MEETING_SCHEDULED_TO_BE_CLOSED = "room_with_active_meeting_scheduled_to_be_closed",
 }
 
 export enum MeetRoomDeletionErrorCode {
-    ROOM_HAS_ACTIVE_MEETING = 'room_has_active_meeting',
-    ROOM_HAS_RECORDINGS = 'room_has_recordings',
-    ROOM_WITH_ACTIVE_MEETING_HAS_RECORDINGS = 'room_with_active_meeting_has_recordings',
-    ROOM_WITH_ACTIVE_MEETING_HAS_RECORDINGS_CANNOT_SCHEDULE_DELETION = 'room_with_active_meeting_has_recordings_cannot_schedule_deletion',
-    ROOM_WITH_RECORDINGS_HAS_ACTIVE_MEETING = 'room_with_recordings_has_active_meeting'
+  ROOM_HAS_ACTIVE_MEETING = "room_has_active_meeting",
+  ROOM_HAS_RECORDINGS = "room_has_recordings",
+  ROOM_WITH_ACTIVE_MEETING_HAS_RECORDINGS = "room_with_active_meeting_has_recordings",
+  ROOM_WITH_ACTIVE_MEETING_HAS_RECORDINGS_CANNOT_SCHEDULE_DELETION = "room_with_active_meeting_has_recordings_cannot_schedule_deletion",
+  ROOM_WITH_RECORDINGS_HAS_ACTIVE_MEETING = "room_with_recordings_has_active_meeting",
 }


### PR DESCRIPTION

### Summary
This PR introduces end-to-end meeting access/security and room policy enhancements:

- add guest captcha backend service, middleware, and global config endpoint  
- enforce/join room passcode with lobby validation and passcode-aware link sharing  
- add room media mode and screen-share access policies, plus max participants setting  
- wire frontend room wizard/basic creation controls and feature gating from token permissions  
- fix share-link UI to render passcode in the same block and improve media-control visibility handling  

### Changes included

#### Backend
- Added captcha validation service and middleware for guest join flow.
- Added global config endpoint to expose guest captcha settings to frontend.
- Added room passcode generation/validation flow:
  - passcode persisted on room creation
  - join token requires correct passcode (when configured)
  - fixed pre-lobby token generation so passcode validation is enforced only on join-permission flow
- Added room media/screen share policy enforcement in token permissions:
  - media mode: `standard` / `video_disabled` / `audio_only`
  - screen share access by role
- Added room max participants enforcement during join-token generation.
- Extended schemas/errors/repository helpers to support the above.

#### Frontend
- Lobby join form supports passcode input + inline invalid-passcode handling.
- Share/copy invite links now include passcode context where applicable.
- Room creation (basic + wizard) supports:
  - passcode
  - max participants
  - media mode
  - screen share access policy
- Feature gating now derives camera/mic/screenshare visibility from token publish-source permissions.
- Share-link component updated to show passcode on next line in same visual block.

#### Typings
- Extended shared room/room-config/room-member typings for:
  - passcode
  - max participants
  - media mode
  - screen share access
  - room passcode in token options

### Why
These changes improve:
- guest access protection (captcha)
- invite security (passcode)
- room policy control (media/screen share/max participants)
- consistency between backend authorization and frontend controls

### Testing performed
- Created rooms with/without passcode and verified join behavior.
- Verified passcode prompt on lobby and invalid-passcode error handling.
- Verified invite/share UI includes passcode.
- Verified media controls visibility under different media modes and screen-share policy.
- Verified max participants join cap behavior.
- Verified no new type errors in touched files.

### Deployment notes
Guest captcha requires these environment variables:

```env
MEET_GUEST_CAPTCHA_ENABLED=true
MEET_GUEST_CAPTCHA_SITE_KEY=<your_recaptcha_site_key>
MEET_GUEST_CAPTCHA_SECRET_KEY=<your_recaptcha_secret_key>
```

Optional disabled/default example:

```env
MEET_GUEST_CAPTCHA_ENABLED=false
MEET_GUEST_CAPTCHA_SITE_KEY=
MEET_GUEST_CAPTCHA_SECRET_KEY=
```