### PR TITLE
chore: update OpenVidu/actions to v1.0.7

### DIFF
--- a/.github/workflows/backend-integration-test.yaml
+++ b/.github/workflows/backend-integration-test.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Build Components
         id: build
-        uses: OpenVidu/actions/build-openvidu-components-angular@974fe3ea43a038d0224bd293131c4087b539a722 # v1.0.6
+        uses: OpenVidu/actions/build-openvidu-components-angular@d8dca35b4da1eab26ba914b64bb441081ff61ffd # v1.0.7
     outputs:
       artifact_name: ${{ steps.build.outputs.artifact_name }}
 
@@ -60,7 +60,7 @@ jobs:
           version: 10.18.3
 
       - name: Setup OpenVidu Local Deployment
-        uses: OpenVidu/actions/start-openvidu-local-deployment@974fe3ea43a038d0224bd293131c4087b539a722 # v1.0.6
+        uses: OpenVidu/actions/start-openvidu-local-deployment@d8dca35b4da1eab26ba914b64bb441081ff61ffd # v1.0.7
         with:
           ref-openvidu-local-deployment: development
           pre_startup_commands: |
@@ -74,7 +74,7 @@ jobs:
             chmod +x pre_startup_commands.sh && ./pre_startup_commands.sh
 
       - name: Setup OpenVidu Meet
-        uses: OpenVidu/actions/start-openvidu-meet@974fe3ea43a038d0224bd293131c4087b539a722 # v1.0.6
+        uses: OpenVidu/actions/start-openvidu-meet@d8dca35b4da1eab26ba914b64bb441081ff61ffd # v1.0.7
         with:
           build_components_angular: 'true'
           components_artifact_name: ${{ needs.build-components.outputs.artifact_name }}
@@ -102,7 +102,7 @@ jobs:
 
       - name: Clean up
         if: always()
-        uses: OpenVidu/actions/cleanup@974fe3ea43a038d0224bd293131c4087b539a722 # v1.0.6
+        uses: OpenVidu/actions/cleanup@d8dca35b4da1eab26ba914b64bb441081ff61ffd # v1.0.7
 
   start-aws-runner-s3:
     name: Prepare AWS runner (S3)
@@ -114,7 +114,7 @@ jobs:
     steps:
       - name: Start AWS EC2 Runner
         id: start-ec2-runner
-        uses: OpenVidu/actions/start-aws-runner@974fe3ea43a038d0224bd293131c4087b539a722 # v1.0.6
+        uses: OpenVidu/actions/start-aws-runner@d8dca35b4da1eab26ba914b64bb441081ff61ffd # v1.0.7
         with:
           aws-instance-type: ${{ inputs.aws-instance-type || 'c5.2xlarge' }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -137,7 +137,7 @@ jobs:
     steps:
       - name: Start AWS EC2 Runner
         id: start-ec2-runner
-        uses: OpenVidu/actions/start-aws-runner@974fe3ea43a038d0224bd293131c4087b539a722 # v1.0.6
+        uses: OpenVidu/actions/start-aws-runner@d8dca35b4da1eab26ba914b64bb441081ff61ffd # v1.0.7
         with:
           aws-instance-type: ${{ inputs.aws-instance-type || 'c5.2xlarge' }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -160,7 +160,7 @@ jobs:
     steps:
       - name: Start AWS EC2 Runner
         id: start-ec2-runner
-        uses: OpenVidu/actions/start-aws-runner@974fe3ea43a038d0224bd293131c4087b539a722 # v1.0.6
+        uses: OpenVidu/actions/start-aws-runner@d8dca35b4da1eab26ba914b64bb441081ff61ffd # v1.0.7
         with:
           aws-instance-type: ${{ inputs.aws-instance-type || 'c5.2xlarge' }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -232,7 +232,7 @@ jobs:
             gsutil -m rm -r gs://openvidu-appdata/openvidu-meet/ || echo "No files found to delete or bucket doesn't exist"
           fi
       - name: Setup OpenVidu Local Deployment
-        uses: OpenVidu/actions/start-openvidu-local-deployment@974fe3ea43a038d0224bd293131c4087b539a722 # v1.0.6
+        uses: OpenVidu/actions/start-openvidu-local-deployment@d8dca35b4da1eab26ba914b64bb441081ff61ffd # v1.0.7
         with:
           ref-openvidu-local-deployment: development
           pre_startup_commands: |
@@ -266,7 +266,7 @@ jobs:
             chmod +x pre_startup_commands.sh && ./pre_startup_commands.sh
 
       - name: Setup OpenVidu Meet
-        uses: OpenVidu/actions/start-openvidu-meet@974fe3ea43a038d0224bd293131c4087b539a722 # v1.0.6
+        uses: OpenVidu/actions/start-openvidu-meet@d8dca35b4da1eab26ba914b64bb441081ff61ffd # v1.0.7
         with:
           build_components_angular: 'true'
           components_artifact_name: ${{ needs.build-components.outputs.artifact_name }}
@@ -317,7 +317,7 @@ jobs:
 
       - name: Clean up
         if: always()
-        uses: OpenVidu/actions/cleanup@974fe3ea43a038d0224bd293131c4087b539a722 # v1.0.6
+        uses: OpenVidu/actions/cleanup@d8dca35b4da1eab26ba914b64bb441081ff61ffd # v1.0.7
 
   stop-runner:
     name: Stop EC2 runner (${{ matrix.storage-provider }})
@@ -335,7 +335,7 @@ jobs:
     steps:
       - name: Stop AWS EC2 Runner
         if: ${{ (matrix.storage-provider == 's3' && needs.start-aws-runner-s3.result != 'skipped') || (matrix.storage-provider == 'abs' && needs.start-aws-runner-abs.result != 'skipped') || (matrix.storage-provider == 'gcs' && needs.start-aws-runner-gcs.result != 'skipped') }}
-        uses: OpenVidu/actions/stop-aws-runner@974fe3ea43a038d0224bd293131c4087b539a722 # v1.0.6
+        uses: OpenVidu/actions/stop-aws-runner@d8dca35b4da1eab26ba914b64bb441081ff61ffd # v1.0.7
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/backend-unit-test.yaml
+++ b/.github/workflows/backend-unit-test.yaml
@@ -41,4 +41,4 @@ jobs:
 
       - name: Clean up
         if: always()
-        uses: OpenVidu/actions/cleanup@974fe3ea43a038d0224bd293131c4087b539a722 # v1.0.6
+        uses: OpenVidu/actions/cleanup@d8dca35b4da1eab26ba914b64bb441081ff61ffd # v1.0.7

--- a/.github/workflows/wc-e2e-test.yaml
+++ b/.github/workflows/wc-e2e-test.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install LK CLI
         run: curl -sSL https://get.livekit.io/cli | bash
       - name: Setup OpenVidu Local Deployment
-        uses: OpenVidu/actions/start-openvidu-local-deployment@974fe3ea43a038d0224bd293131c4087b539a722 # v1.0.6
+        uses: OpenVidu/actions/start-openvidu-local-deployment@d8dca35b4da1eab26ba914b64bb441081ff61ffd # v1.0.7
         with:
           ref-openvidu-local-deployment: development
           pre_startup_commands: |
@@ -34,13 +34,13 @@ jobs:
             chmod +x pre_startup_commands.sh && ./pre_startup_commands.sh
 
       - name: Build and Start OpenVidu Meet
-        uses: OpenVidu/actions/start-openvidu-meet@974fe3ea43a038d0224bd293131c4087b539a722 # v1.0.6
+        uses: OpenVidu/actions/start-openvidu-meet@d8dca35b4da1eab26ba914b64bb441081ff61ffd # v1.0.7
         env:
           MEET_INITIAL_WEBHOOK_ENABLED: true
           MEET_INITIAL_WEBHOOK_URL: 'http://localhost:5080/webhook'
 
       - name: Start OpenVidu Meet Testapp
-        uses: OpenVidu/actions/start-openvidu-meet-testapp@974fe3ea43a038d0224bd293131c4087b539a722 # v1.0.6
+        uses: OpenVidu/actions/start-openvidu-meet-testapp@d8dca35b4da1eab26ba914b64bb441081ff61ffd # v1.0.7
         with:
           skip_install: 'true'
           skip_checkout: 'true'
@@ -79,4 +79,4 @@ jobs:
 
       - name: Clean up
         if: always()
-        uses: OpenVidu/actions/cleanup@974fe3ea43a038d0224bd293131c4087b539a722 # v1.0.6
+        uses: OpenVidu/actions/cleanup@d8dca35b4da1eab26ba914b64bb441081ff61ffd # v1.0.7

--- a/.github/workflows/wc-unit-test.yaml
+++ b/.github/workflows/wc-unit-test.yaml
@@ -34,4 +34,4 @@ jobs:
 
       - name: Clean up
         if: always()
-        uses: OpenVidu/actions/cleanup@974fe3ea43a038d0224bd293131c4087b539a722 # v1.0.6
+        uses: OpenVidu/actions/cleanup@d8dca35b4da1eab26ba914b64bb441081ff61ffd # v1.0.7


### PR DESCRIPTION
Updates pinned references of `OpenVidu/actions` to `v1.0.7`.

Auto-generated by the [update-pinned-actions](https://github.com/OpenVidu/actions/actions/workflows/update-pinned-actions.yml) workflow.