### PR TITLE
chore: update OpenVidu/actions to v1.0.18

### DIFF
--- a/.github/workflows/backend-integration-test.yaml
+++ b/.github/workflows/backend-integration-test.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Build Components
         id: build
-        uses: OpenVidu/actions/build-openvidu-components-angular@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+        uses: OpenVidu/actions/build-openvidu-components-angular@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18
     outputs:
       artifact_name: ${{ steps.build.outputs.artifact_name }}
 
@@ -60,10 +60,10 @@ jobs:
           version: 10.18.3
 
       - name: Install safe-chain
-        uses: OpenVidu/actions/install-safe-chain@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+        uses: OpenVidu/actions/install-safe-chain@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18
 
       - name: Setup OpenVidu Local Deployment
-        uses: OpenVidu/actions/start-openvidu-local-deployment@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+        uses: OpenVidu/actions/start-openvidu-local-deployment@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18
         with:
           ref-openvidu-local-deployment: development
           pre_startup_commands: |
@@ -77,7 +77,7 @@ jobs:
             chmod +x pre_startup_commands.sh && ./pre_startup_commands.sh
 
       - name: Setup OpenVidu Meet
-        uses: OpenVidu/actions/start-openvidu-meet@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+        uses: OpenVidu/actions/start-openvidu-meet@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18
         with:
           build_components_angular: 'true'
           components_artifact_name: ${{ needs.build-components.outputs.artifact_name }}
@@ -105,7 +105,7 @@ jobs:
 
       - name: Clean up
         if: always()
-        uses: OpenVidu/actions/cleanup@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+        uses: OpenVidu/actions/cleanup@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18
 
   start-aws-runner-s3:
     name: Prepare AWS runner (S3)
@@ -117,7 +117,7 @@ jobs:
     steps:
       - name: Start AWS EC2 Runner
         id: start-ec2-runner
-        uses: OpenVidu/actions/start-aws-runner@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+        uses: OpenVidu/actions/start-aws-runner@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18
         with:
           aws-instance-type: ${{ inputs.aws-instance-type || 'c5.2xlarge' }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -140,7 +140,7 @@ jobs:
     steps:
       - name: Start AWS EC2 Runner
         id: start-ec2-runner
-        uses: OpenVidu/actions/start-aws-runner@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+        uses: OpenVidu/actions/start-aws-runner@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18
         with:
           aws-instance-type: ${{ inputs.aws-instance-type || 'c5.2xlarge' }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -163,7 +163,7 @@ jobs:
     steps:
       - name: Start AWS EC2 Runner
         id: start-ec2-runner
-        uses: OpenVidu/actions/start-aws-runner@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+        uses: OpenVidu/actions/start-aws-runner@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18
         with:
           aws-instance-type: ${{ inputs.aws-instance-type || 'c5.2xlarge' }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -200,7 +200,7 @@ jobs:
         with:
           version: 10
       - name: Install safe-chain
-        uses: OpenVidu/actions/install-safe-chain@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+        uses: OpenVidu/actions/install-safe-chain@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18
       - name: Install LK CLI
         run: curl -sSL https://get.livekit.io/cli | bash
       - name: Save GCP credentials
@@ -237,7 +237,7 @@ jobs:
             gsutil -m rm -r gs://openvidu-appdata/openvidu-meet/ || echo "No files found to delete or bucket doesn't exist"
           fi
       - name: Setup OpenVidu Local Deployment
-        uses: OpenVidu/actions/start-openvidu-local-deployment@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+        uses: OpenVidu/actions/start-openvidu-local-deployment@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18
         with:
           ref-openvidu-local-deployment: development
           pre_startup_commands: |
@@ -271,7 +271,7 @@ jobs:
             chmod +x pre_startup_commands.sh && ./pre_startup_commands.sh
 
       - name: Setup OpenVidu Meet
-        uses: OpenVidu/actions/start-openvidu-meet@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+        uses: OpenVidu/actions/start-openvidu-meet@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18
         with:
           build_components_angular: 'true'
           components_artifact_name: ${{ needs.build-components.outputs.artifact_name }}
@@ -322,7 +322,7 @@ jobs:
 
       - name: Clean up
         if: always()
-        uses: OpenVidu/actions/cleanup@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+        uses: OpenVidu/actions/cleanup@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18
 
   stop-runner:
     name: Stop EC2 runner (${{ matrix.storage-provider }})
@@ -340,7 +340,7 @@ jobs:
     steps:
       - name: Stop AWS EC2 Runner
         if: ${{ (matrix.storage-provider == 's3' && needs.start-aws-runner-s3.result != 'skipped') || (matrix.storage-provider == 'abs' && needs.start-aws-runner-abs.result != 'skipped') || (matrix.storage-provider == 'gcs' && needs.start-aws-runner-gcs.result != 'skipped') }}
-        uses: OpenVidu/actions/stop-aws-runner@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+        uses: OpenVidu/actions/stop-aws-runner@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/backend-unit-test.yaml
+++ b/.github/workflows/backend-unit-test.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           version: 10.18.3
       - name: Install safe-chain
-        uses: OpenVidu/actions/install-safe-chain@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+        uses: OpenVidu/actions/install-safe-chain@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18
       - name: Checkout OpenVidu Meet
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -43,4 +43,4 @@ jobs:
 
       - name: Clean up
         if: always()
-        uses: OpenVidu/actions/cleanup@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+        uses: OpenVidu/actions/cleanup@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18

--- a/.github/workflows/wc-e2e-test.yaml
+++ b/.github/workflows/wc-e2e-test.yaml
@@ -18,11 +18,11 @@ jobs:
         with:
           version: 10.18.3
       - name: Install safe-chain
-        uses: OpenVidu/actions/install-safe-chain@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+        uses: OpenVidu/actions/install-safe-chain@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18
       - name: Install LK CLI
         run: curl -sSL https://get.livekit.io/cli | bash
       - name: Setup OpenVidu Local Deployment
-        uses: OpenVidu/actions/start-openvidu-local-deployment@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+        uses: OpenVidu/actions/start-openvidu-local-deployment@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18
         with:
           ref-openvidu-local-deployment: development
           pre_startup_commands: |
@@ -36,13 +36,13 @@ jobs:
             chmod +x pre_startup_commands.sh && ./pre_startup_commands.sh
 
       - name: Build and Start OpenVidu Meet
-        uses: OpenVidu/actions/start-openvidu-meet@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+        uses: OpenVidu/actions/start-openvidu-meet@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18
         env:
           MEET_INITIAL_WEBHOOK_ENABLED: true
           MEET_INITIAL_WEBHOOK_URL: 'http://localhost:5080/webhook'
 
       - name: Start OpenVidu Meet Testapp
-        uses: OpenVidu/actions/start-openvidu-meet-testapp@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+        uses: OpenVidu/actions/start-openvidu-meet-testapp@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18
         with:
           skip_install: 'true'
           skip_checkout: 'true'
@@ -81,4 +81,4 @@ jobs:
 
       - name: Clean up
         if: always()
-        uses: OpenVidu/actions/cleanup@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+        uses: OpenVidu/actions/cleanup@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18

--- a/.github/workflows/wc-unit-test.yaml
+++ b/.github/workflows/wc-unit-test.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           version: 10.18.3
       - name: Install safe-chain
-        uses: OpenVidu/actions/install-safe-chain@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+        uses: OpenVidu/actions/install-safe-chain@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18
       - name: Checkout OpenVidu Meet
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -36,4 +36,4 @@ jobs:
 
       - name: Clean up
         if: always()
-        uses: OpenVidu/actions/cleanup@0125dee363f943e399bf576e8e4c162fafcc5bdd # v1.0.16
+        uses: OpenVidu/actions/cleanup@e585b0ac266d7afffc6cba105b380ad6a477a4c0 # v1.0.18


### PR DESCRIPTION
Updates pinned references of `OpenVidu/actions` to `v1.0.18`.

Auto-generated by the [update-pinned-actions](https://github.com/OpenVidu/actions/actions/workflows/update-pinned-actions.yml) workflow.