### PR TITLE
backend: add rate limiting to authorization route handlers

### DIFF
--- a/meet-ce/backend/src/middlewares/auth.middleware.ts
+++ b/meet-ce/backend/src/middlewares/auth.middleware.ts
@@ -1,7 +1,5 @@
 import type { MeetUserRole } from '@openvidu-meet/typings';
 import type { NextFunction, Request, RequestHandler, Response } from 'express';
-import rateLimit from 'express-rate-limit';
-import ms from 'ms';
 import { container } from '../config/dependency-injector.config.js';
 import { INTERNAL_CONFIG } from '../config/internal-config.js';
 import {
@@ -339,25 +337,4 @@ const setAuthenticatedUserIfPresent = async (req: Request): Promise<void> => {
 		const logger = container.get(LoggerService);
 		logger.debug('Token found but invalid:' + error);
 	}
-};
-
-// Limit login attempts to avoid brute force attacks
-const loginLimiter = rateLimit({
-	windowMs: ms('5m'),
-	limit: 5,
-	skipSuccessfulRequests: true,
-	message: 'Too many login attempts, please try again later',
-	// Use standard draft-7 headers for better proxy compatibility
-	standardHeaders: 'draft-7',
-	// Disable legacy headers
-	legacyHeaders: false
-});
-
-export const withLoginLimiter = (req: Request, res: Response, next: NextFunction) => {
-	// Bypass rate limiting in test environment
-	if (process.env.NODE_ENV === 'test') {
-		return next();
-	}
-
-	return loginLimiter(req, res, next);
 };

--- a/meet-ce/backend/src/middlewares/index.ts
+++ b/meet-ce/backend/src/middlewares/index.ts
@@ -2,6 +2,7 @@
 export * from './auth.middleware.js';
 export * from './base-url.middleware.js';
 export * from './content-type.middleware.js';
+export * from './rate-limit.middleware.js';
 export * from './recording.middleware.js';
 export * from './request-context.middleware.js';
 export * from './room-member.middleware.js';

--- a/meet-ce/backend/src/middlewares/rate-limit.middleware.ts
+++ b/meet-ce/backend/src/middlewares/rate-limit.middleware.ts
@@ -1,6 +1,7 @@
 import type { NextFunction, Request, RequestHandler, Response } from 'express';
 import rateLimit, { type Options } from 'express-rate-limit';
 import ms from 'ms';
+import { INTERNAL_CONFIG } from '../config/internal-config.js';
 
 /**
  * Wraps an express-rate-limit instance so that rate limiting is bypassed in the test environment.
@@ -9,12 +10,15 @@ import ms from 'ms';
  */
 const withTestBypass = (options: Partial<Options>): RequestHandler => {
 	const limiter = rateLimit({
+		// Use standard draft-7 headers for better proxy compatibility
 		standardHeaders: 'draft-7',
+		// Disable legacy headers
 		legacyHeaders: false,
 		...options
 	});
 
 	return (req: Request, res: Response, next: NextFunction) => {
+		// Bypass rate limiting in test environment
 		if (process.env.NODE_ENV === 'test') {
 			return next();
 		}
@@ -22,6 +26,41 @@ const withTestBypass = (options: Partial<Options>): RequestHandler => {
 		return limiter(req, res, next);
 	};
 };
+
+/**
+ * Skips IP-based rate limiting for trusted server-to-server requests authenticated via API key.
+ *
+ * In CE there is a single API key per deployment (see ApiKeyService), shared by an integrator's
+ * backend and originating from a single server IP. IP-based limiting would therefore collapse the
+ * integrator's entire backend into one bucket and throttle their busiest (most legitimate) traffic.
+ * Abuse of the API key itself is an authentication/quota concern, not a rate-limiting one, so we let
+ * these requests through and keep IP-based limiting for browser/end-user traffic on the same routes.
+ */
+const skipApiKeyRequests = (req: Request): boolean => Boolean(req.headers[INTERNAL_CONFIG.API_KEY_HEADER]);
+
+/**
+ * Rate limiter for login attempts. Limits only failed attempts to prevent account lockout.
+ * This strikes a balance between security and usability by allowing legitimate users to log in
+ * without undue friction while still protecting against brute-force password guessing.
+ */
+export const loginLimiter: RequestHandler = withTestBypass({
+	windowMs: ms('5m'),
+	limit: 5,
+	skipSuccessfulRequests: true,
+	message: 'Too many login attempts, please try again later'
+});
+
+/**
+ * Strict rate limiter for sensitive, low-frequency mutating actions performed from the admin/user
+ * console (password changes/resets, user and API-key management, webhook tests). These are guarded by
+ * a session token, so the threat is a scripted or hijacked session rather than anonymous flooding;
+ * the tight ceiling limits brute-force and abuse while staying well above normal interactive use.
+ */
+export const sensitiveActionLimiter: RequestHandler = withTestBypass({
+	windowMs: ms('5m'),
+	limit: 20,
+	message: 'Too many requests for this operation, please try again later'
+});
 
 /**
  * Rate limiter for sensitive authentication endpoints (refresh, logout).
@@ -47,10 +86,14 @@ export const tokenIssuanceLimiter: RequestHandler = withTestBypass({
 /**
  * General-purpose rate limiter for authenticated API routes that perform expensive
  * authorization (DB lookups, signed-URL generation, file system access).
+ *
+ * Skips server-to-server requests authenticated via API key (see skipApiKeyRequests), so it is safe
+ * to apply to the public /api/v1 routes that are multiplexed between integrator backends and browsers.
  */
 export const apiLimiter: RequestHandler = withTestBypass({
 	windowMs: ms('1m'),
 	limit: 120,
+	skip: skipApiKeyRequests,
 	message: 'Too many requests, please try again later'
 });
 

--- a/meet-ce/backend/src/middlewares/rate-limit.middleware.ts
+++ b/meet-ce/backend/src/middlewares/rate-limit.middleware.ts
@@ -1,0 +1,65 @@
+import type { NextFunction, Request, RequestHandler, Response } from 'express';
+import rateLimit, { type Options } from 'express-rate-limit';
+import ms from 'ms';
+
+/**
+ * Wraps an express-rate-limit instance so that rate limiting is bypassed in the test environment.
+ * This keeps integration tests fast and deterministic while still protecting production endpoints
+ * from denial-of-service via request flooding.
+ */
+const withTestBypass = (options: Partial<Options>): RequestHandler => {
+	const limiter = rateLimit({
+		standardHeaders: 'draft-7',
+		legacyHeaders: false,
+		...options
+	});
+
+	return (req: Request, res: Response, next: NextFunction) => {
+		if (process.env.NODE_ENV === 'test') {
+			return next();
+		}
+
+		return limiter(req, res, next);
+	};
+};
+
+/**
+ * Rate limiter for sensitive authentication endpoints (refresh, logout).
+ * Prevents brute-force enumeration and token-grinding attacks.
+ */
+export const authLimiter: RequestHandler = withTestBypass({
+	windowMs: ms('1m'),
+	limit: 30,
+	message: 'Too many authentication requests, please try again later'
+});
+
+/**
+ * Rate limiter for token-generation endpoints (e.g. room member tokens).
+ * These endpoints touch persistent storage and sign cryptographic material, so they
+ * are protected against floods that could exhaust resources.
+ */
+export const tokenIssuanceLimiter: RequestHandler = withTestBypass({
+	windowMs: ms('1m'),
+	limit: 60,
+	message: 'Too many token requests, please try again later'
+});
+
+/**
+ * General-purpose rate limiter for authenticated API routes that perform expensive
+ * authorization (DB lookups, signed-URL generation, file system access).
+ */
+export const apiLimiter: RequestHandler = withTestBypass({
+	windowMs: ms('1m'),
+	limit: 120,
+	message: 'Too many requests, please try again later'
+});
+
+/**
+ * Rate limiter for static asset routes that hit the file system on every request.
+ * Browsers cache these aggressively, so a higher ceiling is appropriate.
+ */
+export const staticAssetLimiter: RequestHandler = withTestBypass({
+	windowMs: ms('1m'),
+	limit: 300,
+	message: 'Too many requests, please try again later'
+});

--- a/meet-ce/backend/src/routes/ai-assistant.routes.ts
+++ b/meet-ce/backend/src/routes/ai-assistant.routes.ts
@@ -2,6 +2,7 @@ import bodyParser from 'body-parser';
 import { Router } from 'express';
 import * as aiAssistantCtrl from '../controllers/ai-assistant.controller.js';
 import { roomMemberTokenValidator, withAuth } from '../middlewares/auth.middleware.js';
+import { apiLimiter } from '../middlewares/rate-limit.middleware.js';
 import {
 	validateAssistantIdPathParam,
 	validateCreateAssistantReq
@@ -10,6 +11,7 @@ import {
 export const aiAssistantRouter: Router = Router();
 aiAssistantRouter.use(bodyParser.urlencoded({ extended: true }));
 aiAssistantRouter.use(bodyParser.json());
+aiAssistantRouter.use(apiLimiter);
 
 aiAssistantRouter.post(
 	'/assistants',

--- a/meet-ce/backend/src/routes/analytics.routes.ts
+++ b/meet-ce/backend/src/routes/analytics.routes.ts
@@ -3,10 +3,12 @@ import bodyParser from 'body-parser';
 import { Router } from 'express';
 import * as analyticsCtrl from '../controllers/analytics.controller.js';
 import { accessTokenValidator, withAuth } from '../middlewares/auth.middleware.js';
+import { apiLimiter } from '../middlewares/rate-limit.middleware.js';
 
 export const analyticsRouter: Router = Router();
 analyticsRouter.use(bodyParser.urlencoded({ extended: true }));
 analyticsRouter.use(bodyParser.json());
+analyticsRouter.use(apiLimiter);
 
 // Analytics Routes
 analyticsRouter.get('/', withAuth(accessTokenValidator(MeetUserRole.ADMIN)), analyticsCtrl.getAnalytics);

--- a/meet-ce/backend/src/routes/api-key.routes.ts
+++ b/meet-ce/backend/src/routes/api-key.routes.ts
@@ -3,10 +3,12 @@ import bodyParser from 'body-parser';
 import { Router } from 'express';
 import * as apiKeyCtrl from '../controllers/api-key.controller.js';
 import { accessTokenValidator, withAuth } from '../middlewares/auth.middleware.js';
+import { sensitiveActionLimiter } from '../middlewares/rate-limit.middleware.js';
 
 export const apiKeyRouter: Router = Router();
 apiKeyRouter.use(bodyParser.urlencoded({ extended: true }));
 apiKeyRouter.use(bodyParser.json());
+apiKeyRouter.use(sensitiveActionLimiter);
 
 // API Key Routes
 apiKeyRouter.post('/', withAuth(accessTokenValidator(MeetUserRole.ADMIN)), apiKeyCtrl.createApiKey);

--- a/meet-ce/backend/src/routes/auth.routes.ts
+++ b/meet-ce/backend/src/routes/auth.routes.ts
@@ -1,8 +1,7 @@
 import bodyParser from 'body-parser';
 import { Router } from 'express';
 import * as authCtrl from '../controllers/auth.controller.js';
-import { withLoginLimiter } from '../middlewares/auth.middleware.js';
-import { authLimiter } from '../middlewares/rate-limit.middleware.js';
+import { authLimiter, loginLimiter } from '../middlewares/rate-limit.middleware.js';
 import { validateLoginReq } from '../middlewares/request-validators/auth-validator.middleware.js';
 
 export const authRouter: Router = Router();
@@ -10,6 +9,6 @@ authRouter.use(bodyParser.urlencoded({ extended: true }));
 authRouter.use(bodyParser.json());
 
 // Auth Routes
-authRouter.post('/login', validateLoginReq, withLoginLimiter, authCtrl.login);
+authRouter.post('/login', loginLimiter, validateLoginReq, authCtrl.login);
 authRouter.post('/logout', authLimiter, authCtrl.logout);
 authRouter.post('/refresh', authLimiter, authCtrl.refreshToken);

--- a/meet-ce/backend/src/routes/auth.routes.ts
+++ b/meet-ce/backend/src/routes/auth.routes.ts
@@ -2,6 +2,7 @@ import bodyParser from 'body-parser';
 import { Router } from 'express';
 import * as authCtrl from '../controllers/auth.controller.js';
 import { withLoginLimiter } from '../middlewares/auth.middleware.js';
+import { authLimiter } from '../middlewares/rate-limit.middleware.js';
 import { validateLoginReq } from '../middlewares/request-validators/auth-validator.middleware.js';
 
 export const authRouter: Router = Router();
@@ -10,5 +11,5 @@ authRouter.use(bodyParser.json());
 
 // Auth Routes
 authRouter.post('/login', validateLoginReq, withLoginLimiter, authCtrl.login);
-authRouter.post('/logout', authCtrl.logout);
-authRouter.post('/refresh', authCtrl.refreshToken);
+authRouter.post('/logout', authLimiter, authCtrl.logout);
+authRouter.post('/refresh', authLimiter, authCtrl.refreshToken);

--- a/meet-ce/backend/src/routes/global-config.routes.ts
+++ b/meet-ce/backend/src/routes/global-config.routes.ts
@@ -3,6 +3,7 @@ import bodyParser from 'body-parser';
 import { Router } from 'express';
 import * as globalConfigCtrl from '../controllers/global-config.controller.js';
 import { accessTokenValidator, allowAnonymous, withAuth } from '../middlewares/auth.middleware.js';
+import { apiLimiter } from '../middlewares/rate-limit.middleware.js';
 import {
 	validateTestWebhookReq,
 	validateUpdateRoomsAppearanceConfigReq,
@@ -13,6 +14,7 @@ import {
 export const configRouter: Router = Router();
 configRouter.use(bodyParser.urlencoded({ extended: true }));
 configRouter.use(bodyParser.json());
+configRouter.use(apiLimiter);
 
 // Webhook config
 configRouter.put(
@@ -22,7 +24,7 @@ configRouter.put(
 	globalConfigCtrl.updateWebhookConfig
 );
 configRouter.get('/webhooks', withAuth(accessTokenValidator(MeetUserRole.ADMIN)), globalConfigCtrl.getWebhookConfig);
-configRouter.post('/webhooks/test', validateTestWebhookReq, globalConfigCtrl.testWebhook);
+configRouter.post('/webhooks/test', withAuth(allowAnonymous), validateTestWebhookReq, globalConfigCtrl.testWebhook);
 
 // Security config
 configRouter.put(

--- a/meet-ce/backend/src/routes/meeting.routes.ts
+++ b/meet-ce/backend/src/routes/meeting.routes.ts
@@ -2,6 +2,7 @@ import bodyParser from 'body-parser';
 import { Router } from 'express';
 import * as meetingCtrl from '../controllers/meeting.controller.js';
 import { roomMemberTokenValidator, withAuth } from '../middlewares/auth.middleware.js';
+import { apiLimiter } from '../middlewares/rate-limit.middleware.js';
 import { validateUpdateParticipantRoleReq } from '../middlewares/request-validators/meeting-validator.middleware.js';
 import { withValidRoomId } from '../middlewares/request-validators/room-validator.middleware.js';
 import { withRoomMemberPermission } from '../middlewares/room-member.middleware.js';
@@ -9,6 +10,7 @@ import { withRoomMemberPermission } from '../middlewares/room-member.middleware.
 export const internalMeetingRouter: Router = Router();
 internalMeetingRouter.use(bodyParser.urlencoded({ extended: true }));
 internalMeetingRouter.use(bodyParser.json());
+internalMeetingRouter.use(apiLimiter);
 
 // Internal Meetings Routes
 internalMeetingRouter.delete(

--- a/meet-ce/backend/src/routes/recording.routes.ts
+++ b/meet-ce/backend/src/routes/recording.routes.ts
@@ -32,6 +32,7 @@ import {
 export const recordingRouter: Router = Router();
 recordingRouter.use(bodyParser.urlencoded({ extended: true }));
 recordingRouter.use(bodyParser.json());
+recordingRouter.use(apiLimiter);
 
 // Recording Routes
 recordingRouter.post(
@@ -77,7 +78,6 @@ recordingRouter.get(
 );
 recordingRouter.get(
 	'/:recordingId',
-	apiLimiter,
 	validateGetRecordingReq,
 	setupRecordingAuthentication,
 	authorizeRecordingAccess('canRetrieveRecordings', true),
@@ -103,7 +103,6 @@ recordingRouter.post(
 );
 recordingRouter.get(
 	'/:recordingId/media',
-	apiLimiter,
 	validateGetRecordingMediaReq,
 	setupRecordingAuthentication,
 	authorizeRecordingAccess('canRetrieveRecordings', true),

--- a/meet-ce/backend/src/routes/recording.routes.ts
+++ b/meet-ce/backend/src/routes/recording.routes.ts
@@ -8,6 +8,7 @@ import {
 	roomMemberTokenValidator,
 	withAuth
 } from '../middlewares/auth.middleware.js';
+import { apiLimiter } from '../middlewares/rate-limit.middleware.js';
 import {
 	applyRecordingListAccessFilters,
 	authorizeRecordingAccess,
@@ -76,6 +77,7 @@ recordingRouter.get(
 );
 recordingRouter.get(
 	'/:recordingId',
+	apiLimiter,
 	validateGetRecordingReq,
 	setupRecordingAuthentication,
 	authorizeRecordingAccess('canRetrieveRecordings', true),
@@ -101,6 +103,7 @@ recordingRouter.post(
 );
 recordingRouter.get(
 	'/:recordingId/media',
+	apiLimiter,
 	validateGetRecordingMediaReq,
 	setupRecordingAuthentication,
 	authorizeRecordingAccess('canRetrieveRecordings', true),

--- a/meet-ce/backend/src/routes/room.routes.ts
+++ b/meet-ce/backend/src/routes/room.routes.ts
@@ -28,7 +28,7 @@ import {
 	validateUpdateRoomStatusReq,
 	withValidRoomId
 } from '../middlewares/request-validators/room-validator.middleware.js';
-import { tokenIssuanceLimiter } from '../middlewares/rate-limit.middleware.js';
+import { apiLimiter, tokenIssuanceLimiter } from '../middlewares/rate-limit.middleware.js';
 import {
 	authorizeRoomMemberAccess,
 	authorizeRoomMemberTokenGeneration,
@@ -44,6 +44,7 @@ import {
 export const roomRouter: Router = Router();
 roomRouter.use(bodyParser.urlencoded({ extended: true }));
 roomRouter.use(bodyParser.json());
+roomRouter.use(apiLimiter);
 
 // Room Routes
 roomRouter.post(

--- a/meet-ce/backend/src/routes/room.routes.ts
+++ b/meet-ce/backend/src/routes/room.routes.ts
@@ -28,6 +28,7 @@ import {
 	validateUpdateRoomStatusReq,
 	withValidRoomId
 } from '../middlewares/request-validators/room-validator.middleware.js';
+import { tokenIssuanceLimiter } from '../middlewares/rate-limit.middleware.js';
 import {
 	authorizeRoomMemberAccess,
 	authorizeRoomMemberTokenGeneration,
@@ -187,10 +188,16 @@ internalRoomRouter.use(bodyParser.json());
 
 internalRoomRouter.post(
 	'/:roomId/members/token',
+	tokenIssuanceLimiter,
 	withValidRoomId,
 	validateCreateRoomMemberTokenReq,
 	setupRoomMemberTokenAuthentication,
 	authorizeRoomMemberTokenGeneration,
 	roomMemberCtrl.generateRoomMemberToken
 );
-internalRoomRouter.post('/:roomId/members/token/refresh', withValidRoomId, roomMemberCtrl.refreshRoomMemberToken);
+internalRoomRouter.post(
+	'/:roomId/members/token/refresh',
+	tokenIssuanceLimiter,
+	withValidRoomId,
+	roomMemberCtrl.refreshRoomMemberToken
+);

--- a/meet-ce/backend/src/routes/user.routes.ts
+++ b/meet-ce/backend/src/routes/user.routes.ts
@@ -3,6 +3,7 @@ import bodyParser from 'body-parser';
 import { Router } from 'express';
 import * as userCtrl from '../controllers/user.controller.js';
 import { accessTokenValidator, withAuth } from '../middlewares/auth.middleware.js';
+import { apiLimiter, sensitiveActionLimiter } from '../middlewares/rate-limit.middleware.js';
 import {
 	validateBulkDeleteUsersReq,
 	validateChangePasswordReq,
@@ -15,6 +16,7 @@ import {
 export const userRouter: Router = Router();
 userRouter.use(bodyParser.urlencoded({ extended: true }));
 userRouter.use(bodyParser.json());
+userRouter.use(apiLimiter);
 
 // Users Routes
 userRouter.post('/', withAuth(accessTokenValidator(MeetUserRole.ADMIN)), validateCreateUserReq, userCtrl.createUser);
@@ -38,6 +40,7 @@ userRouter.get(
 );
 userRouter.post(
 	'/change-password',
+	sensitiveActionLimiter,
 	withAuth(accessTokenValidator(MeetUserRole.ADMIN, MeetUserRole.USER, MeetUserRole.ROOM_MEMBER)),
 	validateChangePasswordReq,
 	userCtrl.changePassword
@@ -46,6 +49,7 @@ userRouter.post(
 userRouter.get('/:userId', withAuth(accessTokenValidator(MeetUserRole.ADMIN, MeetUserRole.USER)), userCtrl.getUser);
 userRouter.put(
 	'/:userId/password',
+	sensitiveActionLimiter,
 	withAuth(accessTokenValidator(MeetUserRole.ADMIN)),
 	validateResetUserPasswordReq,
 	userCtrl.resetUserPassword

--- a/meet-ce/backend/src/server.ts
+++ b/meet-ce/backend/src/server.ts
@@ -78,7 +78,9 @@ const createApp = () => {
 	appRouter.use(express.static(frontendDirectoryPath, { index: false }));
 
 	// Public API routes
-	appRouter.use(`${INTERNAL_CONFIG.API_BASE_PATH_V1}/docs`, (_req: Request, res: Response) =>
+	// Public, unauthenticated docs page: cheap single HTML response, so a generous per-IP ceiling
+	// protects against trivial flooding without affecting legitimate use.
+	appRouter.use(`${INTERNAL_CONFIG.API_BASE_PATH_V1}/docs`, staticAssetLimiter, (_req: Request, res: Response) =>
 		res.type('html').send(getOpenApiHtmlWithBasePath(publicApiHtmlFilePath, INTERNAL_CONFIG.API_BASE_PATH_V1))
 	);
 	appRouter.use(`${INTERNAL_CONFIG.API_BASE_PATH_V1}/rooms`, /*mediaTypeValidatorMiddleware,*/ roomRouter);

--- a/meet-ce/backend/src/server.ts
+++ b/meet-ce/backend/src/server.ts
@@ -8,6 +8,7 @@ import { INTERNAL_CONFIG } from './config/internal-config.js';
 import { MEET_ENV, logEnvVars } from './environment.js';
 import { setBaseUrlFromRequest } from './middlewares/base-url.middleware.js';
 import { jsonSyntaxErrorHandler } from './middlewares/content-type.middleware.js';
+import { staticAssetLimiter } from './middlewares/rate-limit.middleware.js';
 import { initRequestContext } from './middlewares/request-context.middleware.js';
 import { analyticsRouter } from './routes/analytics.routes.js';
 import { aiAssistantRouter } from './routes/ai-assistant.routes.js';
@@ -106,7 +107,9 @@ const createApp = () => {
 	appRouter.use('/health', (_req: Request, res: Response) => res.status(200).send('OK'));
 
 	// Serve OpenVidu Meet webcomponent bundle file
-	appRouter.get('/v1/openvidu-meet.js', (_req: Request, res: Response) => res.sendFile(webcomponentBundlePath));
+	appRouter.get('/v1/openvidu-meet.js', staticAssetLimiter, (_req: Request, res: Response) =>
+		res.sendFile(webcomponentBundlePath)
+	);
 	// Serve OpenVidu Meet index.html file for all non-API routes (with dynamic base path injection)
 	appRouter.get(/^(?!.*\/(api|internal-api)\/).*$/, (_req: Request, res: Response) => {
 		res.type('html').send(getHtmlWithBasePath(frontendHtmlPath));


### PR DESCRIPTION
Protects against denial-of-service by limiting auth, token issuance,
expensive recording lookups, and static asset serving. Adds a reusable
rate-limit middleware module with a test-env bypass mirroring the
existing login limiter.
