### PR TITLE
fix(webhook): always respond to LiveKit webhooks to prevent connection/memory leak

### DIFF
--- a/meet-ce/backend/src/controllers/livekit-webhook.controller.ts
+++ b/meet-ce/backend/src/controllers/livekit-webhook.controller.ts
@@ -23,7 +23,7 @@ export const lkWebhookHandler = async (req: Request, res: Response) => {
 
 		if (!belongsToOpenViduMeet) {
 			logger.verbose(`Webhook skipped: ${webhookEvent.event}. Not related to OpenVidu Meet.`);
-			return;
+			return res.status(200).send();
 		}
 
 		const executionResult = await mutexService.withLock(webhookLockKey, ms('5s'), async () => {

--- a/meet-ce/backend/tests/integration/webhooks/webhook.test.ts
+++ b/meet-ce/backend/tests/integration/webhooks/webhook.test.ts
@@ -393,4 +393,108 @@ describe('Webhook Integration Tests', () => {
 			});
 		});
 	});
+
+	// Regression guard for the webhook memory/fd leak: the handler MUST always send an
+	// HTTP response. If any branch returns without responding, the LiveKit server keeps
+	// the connection open forever (it has no delivery timeout), which pins the
+	// request/response/socket graph in memory and leaks a file descriptor per webhook.
+	// The bug: the "event does not belong to OpenVidu Meet" branch returned without a
+	// response, so plain LiveKit-API usage (rooms not created through Meet) leaked.
+	describe('Webhook handler always responds (no hung connections)', () => {
+		const createWebhookEvent = (id: string, roomName: string, belongsToMeet: boolean): WebhookEvent =>
+			({
+				id,
+				event: 'room_started',
+				room: {
+					name: roomName,
+					metadata: belongsToMeet ? '{"openviduMeet": true}' : '{}'
+				}
+			}) as unknown as WebhookEvent;
+
+		const createMockRequest = (event: WebhookEvent): Request =>
+			({
+				body: JSON.stringify(event),
+				get: (header: string) => (header === 'Authorization' ? 'Bearer test' : undefined)
+			}) as unknown as Request;
+
+		const createMockResponse = () => ({
+			status: jest.fn().mockReturnThis(),
+			send: jest.fn().mockReturnThis()
+		});
+
+		const getWebhookReceiver = (service: LivekitWebhookService) =>
+			(
+				service as unknown as {
+					webhookReceiver: { receive: (body: string, auth?: string) => Promise<WebhookEvent> };
+				}
+			).webhookReceiver;
+
+		const expectResponseSent = (res: ReturnType<typeof createMockResponse>) => {
+			// A 200 must be sent so the underlying HTTP connection can be released.
+			expect(res.status).toHaveBeenCalledWith(200);
+			expect(res.send).toHaveBeenCalled();
+		};
+
+		afterEach(() => {
+			jest.restoreAllMocks();
+		});
+
+		it('responds 200 when the event does NOT belong to OpenVidu Meet (leak regression)', async () => {
+			const service = container.get(LivekitWebhookService);
+			const event = createWebhookEvent('external-event', 'external-room', false);
+
+			jest.spyOn(getWebhookReceiver(service), 'receive').mockResolvedValue(event);
+			jest.spyOn(service, 'webhookEventBelongsToOpenViduMeet').mockResolvedValue(false);
+			const handleRoomStartedSpy = jest.spyOn(service, 'handleRoomStarted');
+
+			const res = createMockResponse();
+			await lkWebhookHandler(createMockRequest(event), res as unknown as Response);
+
+			expectResponseSent(res);
+			// Events for rooms Meet does not own must be skipped, but still acknowledged.
+			expect(handleRoomStartedSpy).not.toHaveBeenCalled();
+		});
+
+		it('responds 200 when the event belongs to OpenVidu Meet and is processed', async () => {
+			const service = container.get(LivekitWebhookService);
+			const event = createWebhookEvent('meet-event', 'meet-room', true);
+
+			jest.spyOn(getWebhookReceiver(service), 'receive').mockResolvedValue(event);
+			jest.spyOn(service, 'webhookEventBelongsToOpenViduMeet').mockResolvedValue(true);
+			jest.spyOn(service, 'handleRoomStarted').mockResolvedValue();
+
+			const res = createMockResponse();
+			await lkWebhookHandler(createMockRequest(event), res as unknown as Response);
+
+			expectResponseSent(res);
+		});
+
+		it('responds 200 when webhook signature verification fails', async () => {
+			const service = container.get(LivekitWebhookService);
+
+			jest.spyOn(getWebhookReceiver(service), 'receive').mockRejectedValue(new Error('invalid signature'));
+
+			const res = createMockResponse();
+			await lkWebhookHandler(
+				createMockRequest({ id: 'bad-signature' } as unknown as WebhookEvent),
+				res as unknown as Response
+			);
+
+			expectResponseSent(res);
+		});
+
+		it('responds 200 even when event processing throws', async () => {
+			const service = container.get(LivekitWebhookService);
+			const event = createWebhookEvent('failing-event', 'failing-room', true);
+
+			jest.spyOn(getWebhookReceiver(service), 'receive').mockResolvedValue(event);
+			jest.spyOn(service, 'webhookEventBelongsToOpenViduMeet').mockResolvedValue(true);
+			jest.spyOn(service, 'handleRoomStarted').mockRejectedValue(new Error('processing boom'));
+
+			const res = createMockResponse();
+			await lkWebhookHandler(createMockRequest(event), res as unknown as Response);
+
+			expectResponseSent(res);
+		});
+	});
 });


### PR DESCRIPTION
## Problem

Applications that use the **LiveKit API directly** (heavy room creation + track egress) make **OpenVidu Meet** leak memory — even when Meet is never opened. Under sustained load the `openvidu-meet` process grows without bound and eventually OOMs.

## Root cause

The LiveKit server fans out every deployment event to Meet's webhook endpoint (`webhook.urls` → `.../livekit/webhook`). In `lkWebhookHandler`, every branch ends by sending `res.status(200).send()` **except** the "event does not belong to OpenVidu Meet" branch, which did a bare `return;`:

```ts
if (!belongsToOpenViduMeet) {
    logger.verbose(`Webhook skipped: ${webhookEvent.event}. Not related to OpenVidu Meet.`);
    return; // ← no response sent → request never completes
}
```

For rooms created through the LiveKit API (not through Meet), `belongsToOpenViduMeet` is `false`, so the HTTP request never gets a response. The LiveKit webhook notifier waits for the response with **no delivery timeout**, so the TCP connection stays `ESTABLISHED` forever. Each hung connection keeps its `IncomingMessage` + `ServerResponse` + `Socket` graph reachable in the Node heap and holds an open file descriptor — a socket/memory/fd leak that scales 1:1 with the number of such webhooks.

## Evidence (before the fix)

Reproduced on an Elastic playground driving load only with `lk` (no Meet UI):

- `openvidu-meet` Node RSS: **134 MB → 184 MB** over two identical load rounds, **monotonic and never reclaimed at idle** (0 rooms / 0 egress between rounds).
- **~2 406 `ESTABLISHED` connections** on the webhook port, all from the LiveKit server, both TCP queues empty, same remote ports over time (stuck, not reconnect churn) — exactly 1:1 with the retained request/response/socket graphs in a heap snapshot, and with the process's open fd count (2 443 fds / 2 420 sockets).
- Direct probes: a **validly-signed** webhook for a room not owned by Meet **hangs (no response >8 s)**; an unsigned one returns `200` in ~2 ms. Isolates the hang to the valid-webhook processing path.

## Fix

Send `res.status(200).send()` in the skip branch so every path acknowledges the webhook and the connection can be released.

## Verification

- **Playground, patched image, same intense workload** (2 000 room creates + 2 000 deletes + 20 track-egress load-tests): connections stay at **0**, RSS **flat**, fds ~30. Signed webhooks now respond `200` in 15–49 ms.
- **New integration test** `meet-ce/backend/tests/integration/webhooks/webhook.test.ts` → *"Webhook handler always responds (no hung connections)"*, run against an `openvidu-local-deployment` (community):
  - **With the fix**: 4/4 pass.
  - **Reverting the one-line fix**: only *"responds 200 when the event does NOT belong to OpenVidu Meet (leak regression)"* fails (`res.status` never called) — confirming it guards the exact bug.

## Notes

- Optional follow-up hardening (not in this PR): ack the webhook before processing (respond `200` first, process async) and/or a delivery timeout on the LiveKit notifier so a slow/failed consumer can't hold connections open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
