### PR TITLE
backend: fix TOCTOU race in room ownership transfer during user deletion

### DIFF
--- a/meet-ce/backend/src/repositories/base.repository.ts
+++ b/meet-ce/backend/src/repositories/base.repository.ts
@@ -170,10 +170,28 @@ export abstract class BaseRepository<TDomain, TDocument extends TDomain = TDomai
 	 * @returns The updated domain object
 	 * @throws Error if document not found or update fails
 	 */
-	protected async updatePartialOne(
+	protected updatePartialOne(
 		filter: QueryFilter<TDocument>,
 		update: UpdateQuery<TDocument> | Partial<TDocument>
-	): Promise<TDomain> {
+	): Promise<TDomain>;
+
+	/**
+	 * Best-effort variant: returns `null` instead of throwing when no document matches the filter
+	 * (e.g. the target was concurrently deleted). Use for updates where a missing document is benign.
+	 */
+	protected updatePartialOne(
+		filter: QueryFilter<TDocument>,
+		update: UpdateQuery<TDocument> | Partial<TDocument>,
+		options: { throwIfNotFound: false }
+	): Promise<TDomain | null>;
+
+	protected async updatePartialOne(
+		filter: QueryFilter<TDocument>,
+		update: UpdateQuery<TDocument> | Partial<TDocument>,
+		options: { throwIfNotFound?: boolean } = {}
+	): Promise<TDomain | null> {
+		const { throwIfNotFound = true } = options;
+
 		try {
 			const isUpdateQuery = Object.keys(update).some((key) => key.startsWith('$'));
 			const safeUpdate = isUpdateQuery
@@ -196,6 +214,11 @@ export abstract class BaseRepository<TDomain, TDocument extends TDomain = TDomai
 
 			if (!document) {
 				this.logger.error('No document found to update with filter:', filter);
+
+				if (!throwIfNotFound) {
+					return null;
+				}
+
 				throw new Error('Document not found for update');
 			}
 

--- a/meet-ce/backend/src/repositories/room.repository.ts
+++ b/meet-ce/backend/src/repositories/room.repository.ts
@@ -83,6 +83,20 @@ export class RoomRepository extends BaseRepository<MeetRoom, MeetRoomDocument> {
 	}
 
 	/**
+	 * Best-effort variant of {@link updatePartial}: returns `null` instead of throwing when the room
+	 * no longer exists (e.g. it was concurrently deleted). Use for updates where a missing room is
+	 * benign, such as reassigning ownership while the room is being deleted.
+	 *
+	 * @param roomId - The unique room identifier
+	 * @param fieldsToUpdate - Partial room data with fields to update
+	 * @returns The updated room with enriched URLs, or `null` if the room no longer exists
+	 */
+	updatePartialIfExists(roomId: string, fieldsToUpdate: Partial<MeetRoom>): Promise<MeetRoom | null> {
+		const normalizedFieldsToUpdate = this.normalizeRoomForStorage(fieldsToUpdate);
+		return this.updatePartialOne({ roomId }, normalizedFieldsToUpdate, { throwIfNotFound: false });
+	}
+
+	/**
 	 * Replaces an existing room with new data.
 	 * URLs are stored in the database without the base URL.
 	 *

--- a/meet-ce/backend/src/services/user.service.ts
+++ b/meet-ce/backend/src/services/user.service.ts
@@ -221,21 +221,11 @@ export class UserService {
 			const ownedRooms = await this.roomRepository.findByOwner(userId, ['roomId']);
 
 			if (ownedRooms.length > 0) {
-				await runConcurrently(
-					ownedRooms,
-					async (room) => {
-						await Promise.all([
-							this.roomRepository.updatePartial(room.roomId, { owner: MEET_ENV.INITIAL_ADMIN_USER }),
-							this.recordingRepository.updateAccessScopeMetadataByRoomId(room.roomId, {
-								roomOwner: MEET_ENV.INITIAL_ADMIN_USER
-							})
-						]);
-					},
-					{ concurrency: INTERNAL_CONFIG.CONCURRENCY_BULK_CLEANUP_USER_RESOURCES, failFast: true }
-				);
-
+				const adminUserId = MEET_ENV.INITIAL_ADMIN_USER;
+				const { transferred, skipped } = await this.transferOwnedRoomsToAdmin(ownedRooms, adminUserId);
 				this.logger.info(
-					`Transferred ownership of ${ownedRooms.length} room(s) from user '${userId}' to admin '${MEET_ENV.INITIAL_ADMIN_USER}' due to role change to '${MeetUserRole.ROOM_MEMBER}'`
+					`Transferred ownership of ${transferred} room(s) from user '${userId}' to admin '${adminUserId}' due to role change to '${MeetUserRole.ROOM_MEMBER}'` +
+						(skipped > 0 ? ` (skipped ${skipped} room(s) deleted concurrently)` : '')
 				);
 			}
 		}
@@ -405,26 +395,50 @@ export class UserService {
 		const allOwnedRooms = userCleanupResults.flat();
 
 		if (allOwnedRooms.length > 0) {
-			await runConcurrently(
-				allOwnedRooms,
-				async (room) => {
-					await Promise.all([
-						// Transfer ownership to admin user
-						this.roomRepository.updatePartial(room.roomId, { owner: adminUserId }),
-						this.recordingRepository.updateAccessScopeMetadataByRoomId(room.roomId, {
-							roomOwner: adminUserId
-						})
-					]);
-				},
-				{ concurrency, failFast: true }
-			);
-
+			const { transferred, skipped } = await this.transferOwnedRoomsToAdmin(allOwnedRooms, adminUserId);
 			this.logger.info(
-				`Transferred ownership of ${allOwnedRooms.length} room(s) from ${userIds.length} user(s) to admin '${adminUserId}'`
+				`Transferred ownership of ${transferred} room(s) from ${userIds.length} user(s) to admin '${adminUserId}'` +
+					(skipped > 0 ? ` (skipped ${skipped} room(s) deleted concurrently)` : '')
 			);
 		}
 
 		this.logger.info(`Completed cleanup for ${userIds.length} user(s)`);
+	}
+
+	/**
+	 * Transfers ownership of the given rooms to the admin user, tolerating rooms that are deleted
+	 * concurrently (e.g. a parallel room deletion during account cleanup or a role change).
+	 *
+	 * `updatePartialIfExists` returns `null` instead of throwing when the room no longer exists, so
+	 * transferring ownership of a deleted room is treated as a benign no-op and skipped rather than
+	 * propagated as an error through the fail-fast pool. The recording metadata update is already
+	 * tolerant of a missing room (`updateMany` matches nothing).
+	 *
+	 * @param rooms - Rooms to transfer, identified by `roomId`
+	 * @param adminUserId - The admin user to receive ownership
+	 * @returns Counts of rooms whose ownership was transferred vs skipped because they no longer exist
+	 */
+	private async transferOwnedRoomsToAdmin(
+		rooms: { roomId: string }[],
+		adminUserId: string
+	): Promise<{ transferred: number; skipped: number }> {
+		const transferResults = await runConcurrently(
+			rooms,
+			async (room) => {
+				const [transferredRoom] = await Promise.all([
+					this.roomRepository.updatePartialIfExists(room.roomId, { owner: adminUserId }),
+					this.recordingRepository.updateAccessScopeMetadataByRoomId(room.roomId, {
+						roomOwner: adminUserId
+					})
+				]);
+
+				return transferredRoom !== null;
+			},
+			{ concurrency: INTERNAL_CONFIG.CONCURRENCY_BULK_CLEANUP_USER_RESOURCES, failFast: true }
+		);
+
+		const transferred = transferResults.filter(Boolean).length;
+		return { transferred, skipped: transferResults.length - transferred };
 	}
 
 	// Convert user to UserDTO to remove sensitive information

--- a/meet-ce/backend/tests/integration/api/users/bulk-delete-users.test.ts
+++ b/meet-ce/backend/tests/integration/api/users/bulk-delete-users.test.ts
@@ -1,9 +1,11 @@
-import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 import { MeetRoomMemberRole, MeetRoomMemberTokenMetadata, MeetUserRole } from '@openvidu-meet/typings';
 import { container } from '../../../../src/config/dependency-injector.config.js';
 import { MEET_ENV } from '../../../../src/environment.js';
 import { OpenViduMeetError } from '../../../../src/models/error.model.js';
 import { MeetRecordingModel } from '../../../../src/models/mongoose-schemas/recording.schema.js';
+import { MeetRoomModel } from '../../../../src/models/mongoose-schemas/room.schema.js';
+import { RoomRepository } from '../../../../src/repositories/room.repository.js';
 import { LivekitWebhookService } from '../../../../src/services/livekit-webhook.service.js';
 import { LiveKitService } from '../../../../src/services/livekit.service.js';
 import { TokenService } from '../../../../src/services/token.service.js';
@@ -186,6 +188,53 @@ describe('Users API Tests', () => {
 
 			const getRoom3Response = await getRoom(room3.roomId);
 			expect(getRoom3Response.body).toHaveProperty('owner', MEET_ENV.INITIAL_ADMIN_USER);
+		});
+
+		it('should tolerate a room being deleted concurrently during ownership transfer (TOCTOU)', async () => {
+			// Regression test for the concurrency bug where a room owned by a user being deleted was itself
+			// deleted in the window between reading the owned rooms and transferring their ownership. The
+			// stale read scheduled a transfer that then hit a missing room, which used to throw
+			// 'Document not found for update' and surface as a masked 500.
+			const ownerData = await createUserWithRole(MeetUserRole.ROOM_MANAGER);
+			const room = await createRoom(undefined, ownerData.accessToken);
+
+			// Deterministically reproduce the race: patch the shared repository instance so that reading the
+			// user's owned rooms also deletes the room, mimicking a parallel room deletion landing in the
+			// TOCTOU window. `findByOwner` still returns the (now stale) room, so the transfer step is
+			// exercised against a room that no longer exists.
+			const roomRepository = container.get(RoomRepository);
+			const realFindByOwner = roomRepository.findByOwner.bind(roomRepository);
+			const findByOwnerSpy = jest
+				.spyOn(roomRepository as any, 'findByOwner')
+				.mockImplementation(async (...args: any[]) => {
+					const rooms = await (realFindByOwner as any)(...args);
+
+					if (args[0] === ownerData.user.userId) {
+						await MeetRoomModel.deleteOne({ roomId: room.roomId }).exec();
+					}
+
+					return rooms;
+				});
+
+			try {
+				const response = await bulkDeleteUsers([ownerData.user.userId]);
+
+				// Before the fix this returned 500 ('Unexpected error while deleting users').
+				expect(response.status).toBe(200);
+				expect(response.body.deleted).toContain(ownerData.user.userId);
+				expect(response.body.failed).toHaveLength(0);
+				expect(findByOwnerSpy).toHaveBeenCalled();
+			} finally {
+				findByOwnerSpy.mockRestore();
+			}
+
+			// The concurrently deleted room stays deleted; ownership transfer was correctly skipped.
+			const getRoomResponse = await getRoom(room.roomId);
+			expect(getRoomResponse.status).toBe(404);
+
+			// The user was still fully deleted despite the skipped transfer.
+			const getUserResponse = await getUser(ownerData.user.userId);
+			expect(getUserResponse.status).toBe(404);
 		});
 
 		it('should update recording roomOwner when ownership is transferred by bulk delete', async () => {

--- a/meet-ce/backend/tests/integration/api/users/update-user-role.test.ts
+++ b/meet-ce/backend/tests/integration/api/users/update-user-role.test.ts
@@ -3,6 +3,8 @@ import { MeetRoomMemberRole, MeetRoomMemberTokenMetadata, MeetSignalType, MeetUs
 import { container } from '../../../../src/config/dependency-injector.config.js';
 import { MEET_ENV } from '../../../../src/environment.js';
 import { MeetRecordingModel } from '../../../../src/models/mongoose-schemas/recording.schema.js';
+import { MeetRoomModel } from '../../../../src/models/mongoose-schemas/room.schema.js';
+import { RoomRepository } from '../../../../src/repositories/room.repository.js';
 import { FrontendEventService } from '../../../../src/services/frontend-event.service.js';
 import { LivekitWebhookService } from '../../../../src/services/livekit-webhook.service.js';
 import { LiveKitService } from '../../../../src/services/livekit.service.js';
@@ -181,6 +183,51 @@ describe('Users API Tests', () => {
 			const updatedRoomResponse = await getRoom(room.roomId);
 			expect(updatedRoomResponse.status).toBe(200);
 			expect(updatedRoomResponse.body.owner).toBe(MEET_ENV.INITIAL_ADMIN_USER);
+		});
+
+		it('should tolerate a room being deleted concurrently during role-change ownership transfer (TOCTOU)', async () => {
+			// Regression test for the same concurrency bug on the role-change path: demoting a ROOM_MANAGER
+			// to ROOM_MEMBER transfers owned rooms to the root admin. A room deleted in the window between
+			// reading owned rooms and transferring them used to throw and surface a masked 500.
+			const userId = `user_${Date.now()}`;
+			const userData = await setupUser({
+				userId,
+				name: 'Test User',
+				password: 'password123',
+				role: MeetUserRole.ROOM_MANAGER
+			});
+			const room = await createRoom(undefined, userData.accessToken);
+
+			// Deterministically reproduce the race: reading the user's owned rooms also deletes the room, so
+			// the subsequent ownership transfer runs against a room that no longer exists.
+			const roomRepository = container.get(RoomRepository);
+			const realFindByOwner = roomRepository.findByOwner.bind(roomRepository);
+			const findByOwnerSpy = jest
+				.spyOn(roomRepository as any, 'findByOwner')
+				.mockImplementation(async (...args: any[]) => {
+					const rooms = await (realFindByOwner as any)(...args);
+
+					if (args[0] === userId) {
+						await MeetRoomModel.deleteOne({ roomId: room.roomId }).exec();
+					}
+
+					return rooms;
+				});
+
+			try {
+				const result = await updateUserRole(userId, MeetUserRole.ROOM_MEMBER);
+
+				// Before the fix this returned 500.
+				expect(result.status).toBe(200);
+				expect(result.body.role).toBe(MeetUserRole.ROOM_MEMBER);
+				expect(findByOwnerSpy).toHaveBeenCalled();
+			} finally {
+				findByOwnerSpy.mockRestore();
+			}
+
+			// The concurrently deleted room stays deleted; ownership transfer was correctly skipped.
+			const getRoomResponse = await getRoom(room.roomId);
+			expect(getRoomResponse.status).toBe(404);
 		});
 
 		it('should update recording roomOwner when ownership is transferred by role change', async () => {


### PR DESCRIPTION
## Summary
- Fixes a real concurrency bug (confirmed via deterministic local repro): deleting a user in parallel with deleting one of their owned rooms could throw `'Document not found for update'` while transferring room ownership to the admin user, since the room was read as existing but was deleted before the ownership write landed. The transfer pool is `failFast: true`, so this propagated and got masked as a generic 500 ("Unexpected error while deleting users").
- Adds a non-throwing `updatePartialOne`/`updatePartial` variant (`{ throwIfNotFound: false }` → returns `null` instead of throwing) for the one case where a missing document is a benign outcome of a legitimate race, not an error.
- Extracts a shared `transferOwnedRoomsToAdmin` helper in `UserService` and routes **both** ownership-transfer call sites through it — bulk user deletion (`bulkCleanupUserResources`) and role-change demotion (`changeUserRole`, ROOM_MANAGER/ADMIN → ROOM_MEMBER) — since both had the identical latent TOCTOU.

## Test plan
- [x] Added deterministic regression tests (no timing hacks) that spy on the shared `RoomRepository.findByOwner` so reading a user's owned rooms also deletes the room, reproducing the exact race window on demand — one test per fixed endpoint (`bulk-delete-users.test.ts`, `update-user-role.test.ts`).
- [x] Confirmed both new tests fail with the pre-fix code (`500`, "Unexpected error while deleting users") and pass with the fix (`200`, transfer skipped, room stays deleted, user still fully deleted).
- [x] `tsc -p tsconfig.json --noEmit` clean.
- [x] Full `tests/integration/api/users/*` suite green (45/45), confirming no regressions to existing ownership-transfer behavior.